### PR TITLE
fix(skills-sync): fix 3 pipeline bugs that silently dropped docs changes

### DIFF
--- a/.github/workflows/docs-sync-skills.yml
+++ b/.github/workflows/docs-sync-skills.yml
@@ -343,6 +343,7 @@ jobs:
       - name: Apply matrix patches
         env:
           INCOMING_DIR:      ${{ github.workspace }}/incoming/agent-skills-patches
+          DOWNLOAD_ROOT:     ${{ github.workspace }}/incoming
           AGENT_SKILLS_DIR:  ${{ github.workspace }}/agent-skills
         run: bash docs/scripts/skills-sync/apply-patches.sh
 
@@ -395,6 +396,36 @@ jobs:
           GH_TOKEN:          ${{ secrets.CROSS_REPO_PAT }}
           DOCS_DIR: ${{ github.workspace }}/docs
         run: bash docs/scripts/skills-sync/run-claude-agent.sh skill-pr-composer
+
+      - name: Annotate unmapped changes
+        if: always()
+        run: |
+          if [ ! -f outputs/plan.json ]; then exit 0; fi
+          UNMAPPED=$(jq '.unmapped | length' outputs/plan.json)
+          if [ "$UNMAPPED" -gt 0 ]; then
+            echo "::warning::$UNMAPPED docs change(s) could not be mapped to any skill. Review plan.json → unmapped[]"
+            jq -r '.unmapped[] | "  - \(.feature) → suggested: \(.suggested_slug // "unknown")"' outputs/plan.json
+          fi
+
+      - name: Assert PR was created or updated
+        run: |
+          TICKETS=$(jq -r '[.tickets[].skill] | length' outputs/plan.json 2>/dev/null || echo "0")
+          if [ "$TICKETS" -eq 0 ]; then
+            echo "No tickets — skipping PR assertion"
+            exit 0
+          fi
+          if [ ! -f outputs/pr-composer-result.json ]; then
+            echo "::error::Pipeline had $TICKETS ticket(s) but Agent 4 produced no pr-composer-result.json"
+            echo "::error::changes-merged.json contents: $(cat outputs/changes-merged.json 2>/dev/null || echo 'missing')"
+            exit 1
+          fi
+          PR_URL=$(jq -r '.pr_url // empty' outputs/pr-composer-result.json)
+          if [ -z "$PR_URL" ]; then
+            echo "::error::Pipeline had $TICKETS ticket(s) but no PR was created or updated"
+            echo "::error::changes-merged.json contents: $(cat outputs/changes-merged.json 2>/dev/null || echo 'missing')"
+            exit 1
+          fi
+          echo "PR: $PR_URL"
 
       - name: Upload pipeline run summary
         if: always()

--- a/scripts/skills-sync/apply-patches.sh
+++ b/scripts/skills-sync/apply-patches.sh
@@ -22,6 +22,7 @@
 set -euo pipefail
 
 INCOMING_DIR="${INCOMING_DIR:-$PWD/incoming}"
+DOWNLOAD_ROOT="${DOWNLOAD_ROOT:-$PWD/incoming}"
 AGENT_SKILLS_DIR="${AGENT_SKILLS_DIR:-$PWD/agent-skills}"
 OUT_DIR="${OUT_DIR:-$PWD/outputs}"
 
@@ -29,7 +30,9 @@ mkdir -p "$OUT_DIR"
 
 shopt -s nullglob
 PATCHES=( "$INCOMING_DIR"/*.patch )
-CHANGES=( "$INCOMING_DIR"/changes.json "$INCOMING_DIR"/*/changes.json )
+# changes.json lives under outputs/ in each artifact, which extracts to
+# $DOWNLOAD_ROOT/outputs/ — NOT inside $INCOMING_DIR (agent-skills-patches/).
+CHANGES=( "$DOWNLOAD_ROOT"/changes.json "$DOWNLOAD_ROOT"/*/changes.json )
 shopt -u nullglob
 
 if [ ${#PATCHES[@]} -eq 0 ]; then

--- a/scripts/skills-sync/reference-artifacts/mapping.md
+++ b/scripts/skills-sync/reference-artifacts/mapping.md
@@ -29,10 +29,27 @@
 | `api-reference/rest-apis/v1/**`, `api-reference/rest-apis/v2/**` | `velt-rest-apis-best-practices` |
 | `api-reference/sdk/api/api-methods.mdx` | route by method family (match `<Feature>Element` or service name to skill) |
 | `api-reference/sdk/api/react-hooks.mdx` | route by hook family (match `use<Feature>` to skill) |
-| `api-reference/sdk/models/data-models.mdx` | route by model family (match type prefix to skill) |
+| `api-reference/sdk/models/data-models.mdx` | route by model family (see §model-family routing below) |
 | `async-collaboration/suggestions/**` | `velt-suggestions-best-practices` (unmapped — new skill needed) |
 | `webhooks/basic.mdx`, `webhooks/advanced.mdx` | route by event family (see §webhook routing) |
 | `ui-customization/features/<feature>/**` | skill matching `<feature>` (e.g., `comments` → `velt-comments-best-practices`) |
+
+## Model-family routing
+
+`data-models.mdx` is cross-cutting. The planner examines diff hunks for type names and routes to the owning skill:
+
+| Type prefix | Target skill |
+|---|---|
+| `CommentAnnotation`, `Comment`, `PartialComment`, `CommentAnnotationAgent`, `AgentResult`, `CommentAnnotationSuggestion` | `velt-comments-best-practices` |
+| `PermissionRequest`, `PermissionProvider`, `PermissionResponse` | `velt-setup-best-practices` |
+| `NotificationData`, `Notification`, `NotificationEvent` | `velt-notifications-best-practices` |
+| `RecorderData`, `Recording`, `RecordingAnnotation` | `velt-recorder-best-practices` |
+| `PresenceUser`, `Presence` | `velt-presence-best-practices` |
+| `CursorUser`, `Cursor` | `velt-cursors-best-practices` |
+| `HuddleData`, `Huddle` | `velt-huddle-best-practices` |
+| `BaseMetadata`, `User`, `UserContact` | (cross-cutting — route to skill matching the changed section's heading context) |
+
+If a type name doesn't match any prefix above, check the `#### <TypeName>` heading's enclosing section in the diff for context clues (e.g., if it appears under "Permission Models", route to `velt-setup-best-practices`). Do **not** send to `unmapped` unless you've exhausted both the prefix table and the heading context.
 
 ## Webhook routing
 


### PR DESCRIPTION
## Summary

The skills-sync pipeline ran for all 7 recent docs commits but silently failed to produce PRs for 5 of them. Root cause analysis found 3 independent bugs:

- **Bug 1 (highest impact):** `apply-patches.sh` searched for `changes.json` at `$INCOMING_DIR/changes.json` (`incoming/agent-skills-patches/`) but `actions/download-artifact` with `merge-multiple` extracts it to `incoming/outputs/changes.json`. The glob never matched, so `changes-merged.json` was always `[]` and Agent 4 skipped PR creation. Fixed by adding a `$DOWNLOAD_ROOT` variable that points to the artifact extraction root.

- **Bug 2:** `data-models.mdx` changes for `PermissionRequest.resource.parentFolderId` were classified as "unmapped" because the planner couldn't match the type prefix to any skill. Added an explicit model-family routing table to `mapping.md` (similar to the existing webhook routing table).

- **Bug 3:** Pipeline exited with `conclusion: success` even when no PR was created. Added an assertion step that fails when the planner found tickets but no PR was produced, and an annotation that warns on unmapped changes.

## Affected runs

| Docs commit | What was lost | Bug |
|---|---|---|
| `ba3c2029` (beta.29) | `parentFolderId` → setup skill | Bug 2 |
| `1ee07157` (beta.30) | `basicAnchorData` → comments skill | Bug 1 |
| `e5263b8f` (beta.32) | agent annotation models → comments skill | Bug 1 |
| `32717529` (node v1.0.2) | `PartialCommentAnnotation` → node-sdk skill | Bug 1 |

These changes were manually applied to agent-skills in a separate session.

## Test plan

- [ ] After merge, re-run via `workflow_dispatch` for `ba3c2029` — should now create a ticket for `velt-setup-best-practices` instead of unmapped
- [ ] Re-run for `1ee07157` — `changes-merged.json` should be non-empty, PR should be created
- [ ] Verify a run with no tickets still exits cleanly (no false positive from the assertion step)
- [ ] Verify unmapped annotation appears as a GitHub Actions warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)