### PR TITLE
fix(skills-sync): prepend execution instruction to agent prompts

### DIFF
--- a/scripts/skills-sync/run-claude-agent.sh
+++ b/scripts/skills-sync/run-claude-agent.sh
@@ -58,7 +58,13 @@ MODEL="${MODEL:-claude-opus-4-7}"
 
 # Strip the YAML frontmatter so we pass just the agent body as the user prompt.
 # Convention: frontmatter is fenced by two `---` lines at the top.
-BODY="$(awk 'BEGIN{f=0} /^---$/{f++; next} f>=2{print}' "$AGENT_FILE")"
+RAW_BODY="$(awk 'BEGIN{f=0} /^---$/{f++; next} f>=2{print}' "$AGENT_FILE")"
+
+# Prepend an explicit execution instruction so the model treats the body as
+# imperative instructions rather than informational context.
+BODY="Execute the following skill instructions NOW against the files in your working directory. Do not ask clarifying questions — read the input files and carry out every step.
+
+${RAW_BODY}"
 
 if [ -z "${BODY//[[:space:]]/}" ]; then
   echo "run-claude-agent.sh: agent body is empty after stripping frontmatter — refusing to run" >&2


### PR DESCRIPTION
## Summary

Agent 4 (skill-pr-composer) intermittently refuses to execute, treating its prompt as informational context and responding with "what would you like me to do?" instead of reading input files and creating a PR. This caused the pipeline to fail for commits `2f8c5e2` and `eef483f` — both on attempt 1 and rerun attempt 2.

The fix prepends an explicit imperative instruction to the agent body in `run-claude-agent.sh`:

> "Execute the following skill instructions NOW against the files in your working directory. Do not ask clarifying questions — read the input files and carry out every step."

This applies to all 8 agents, not just Agent 4, as a defensive measure.

## Test plan

- [ ] Rerun the two failed pipelines after merge and confirm Agent 4 executes correctly
- [ ] Verify the other agents (1, 2a-2f, 3) still work correctly with the prepended instruction

🤖 Generated with [Claude Code](https://claude.com/claude-code)