### PR TITLE
fix(skills-sync): generate patches against the accumulator branch so they apply

### DIFF
--- a/.github/workflows/docs-sync-skills.yml
+++ b/.github/workflows/docs-sync-skills.yml
@@ -59,6 +59,10 @@ jobs:
       tickets:     ${{ steps.gate.outputs.tickets }}
       target_sha:  ${{ steps.resolve-shas.outputs.target_sha }}
       before_sha:  ${{ steps.resolve-shas.outputs.before_sha }}
+      # The agent-skills ref that patches must be GENERATED against so they
+      # apply cleanly onto the same ref in validate-and-pr. If an open
+      # skills-sync PR exists, that's its (accumulator) branch; otherwise main.
+      base_ref:    ${{ steps.resolve-base-ref.outputs.base_ref }}
 
     steps:
       - name: Checkout docs (full history)
@@ -74,6 +78,30 @@ jobs:
           token: ${{ secrets.CROSS_REPO_PAT }}
           path: agent-skills
           fetch-depth: 1
+
+      - name: Resolve agent-skills base ref (reuse open skills-sync PR branch)
+        id: resolve-base-ref
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_REPO_PAT }}
+        run: |
+          # Patches are generated (update-skill) and applied (validate-and-pr)
+          # against agent-skills. They MUST share a base, or hunks like the
+          # metadata.json version line fail to apply. If an open skills-sync PR
+          # exists, its branch is the accumulator that validate-and-pr commits
+          # onto — so generate against that branch. Otherwise generate against main.
+          EXISTING=$(gh pr list \
+            --repo ${{ env.AGENT_SKILLS_REPO }} \
+            --state open \
+            --label skills-sync \
+            --json headRefName,updatedAt \
+            --jq 'sort_by(.updatedAt) | reverse | .[0].headRefName // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "base_ref=$EXISTING" >> "$GITHUB_OUTPUT"
+            echo "Open skills-sync PR found — patch base is its branch: $EXISTING"
+          else
+            echo "base_ref=main" >> "$GITHUB_OUTPUT"
+            echo "No open skills-sync PR — patch base is main"
+          fi
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -173,6 +201,11 @@ jobs:
           repository: ${{ env.AGENT_SKILLS_REPO }}
           token: ${{ secrets.CROSS_REPO_PAT }}
           path: agent-skills
+          # Generate the patch against the SAME ref validate-and-pr applies onto
+          # (the open skills-sync PR's accumulator branch, else main). Without
+          # this the patch is built against main and fails to apply onto a
+          # drifted accumulator branch (e.g. an already-bumped metadata.json).
+          ref: ${{ needs.plan.outputs.base_ref }}
           fetch-depth: 1
 
       - name: Set up Node.js
@@ -426,6 +459,27 @@ jobs:
             exit 1
           fi
           echo "PR: $PR_URL"
+
+      - name: Notify on failure (never fail silently)
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_REPO_PAT }}
+        run: |
+          DOCS_SHA="${{ needs.plan.outputs.target_sha }}"
+          SHORT="$(echo "$DOCS_SHA" | cut -c1-7)"
+          DOCS_URL="${{ github.server_url }}/${{ github.repository }}/commit/$DOCS_SHA"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          MSG="⚠️ skills-sync failed for docs@${SHORT} (${DOCS_URL}). Those docs changes were **not** synced to agent-skills. Pipeline run: ${RUN_URL}"
+          # Prefer a comment on the open skills-sync PR; otherwise open an issue so
+          # a failed run is always surfaced and never silently dropped.
+          if [ -n "${EXISTING_PR_NUMBER:-}" ]; then
+            gh pr comment "$EXISTING_PR_NUMBER" --repo ${{ env.AGENT_SKILLS_REPO }} --body "$MSG" || true
+          else
+            gh issue create --repo ${{ env.AGENT_SKILLS_REPO }} \
+              --title "skills-sync: failed to sync docs@${SHORT}" \
+              --body "$MSG" \
+              --label skills-sync || true
+          fi
 
       - name: Upload pipeline run summary
         if: always()

--- a/scripts/skills-sync/apply-patches.sh
+++ b/scripts/skills-sync/apply-patches.sh
@@ -46,12 +46,16 @@ echo "[apply-patches] Applying ${#PATCHES[@]} patch(es) to $AGENT_SKILLS_DIR"
 cd "$AGENT_SKILLS_DIR"
 for patch in "${PATCHES[@]}"; do
   echo "  - $(basename "$patch")"
-  # --3way leaves conflict markers if there's a conflict; we want a clean apply.
-  git apply --index --check "$patch" 2>&1 || {
-    echo "apply-patches.sh: patch failed precheck: $patch" >&2
+  # --3way lets a patch generated against a slightly different base (e.g. an
+  # accumulator branch that already bumped metadata.json) still apply via a
+  # 3-way merge instead of failing on stale context. With the patch generated
+  # against the same ref it's applied onto (see docs-sync-skills.yml base_ref),
+  # the normal path applies cleanly; --3way is the safety net. A genuine
+  # conflict still fails loudly rather than being silently skipped.
+  git apply --index --3way "$patch" 2>&1 || {
+    echo "apply-patches.sh: patch failed to apply (3-way): $patch" >&2
     exit 2
   }
-  git apply --index "$patch"
 done
 
 # Merge all changes.json files into a single array


### PR DESCRIPTION
## What & why

The docs→agent-skills `docs-sync-skills` pipeline silently stopped landing changes after 2026-06-10. Three in-scope docs commits failed to sync and the only open accumulator PR ([agent-skills#9](https://github.com/velt-js/agent-skills/pull/9)) was missing them:

| Docs commit | Run | Failure |
|---|---|---|
| `7fda805` (#197) | [27253988840](https://github.com/velt-js/docs/actions/runs/27253988840) | `apply-patches.sh` precheck on `metadata.json:1` |
| `9a2fbf4` (#204) | [27310434269](https://github.com/velt-js/docs/actions/runs/27310434269) | precheck on `metadata.json:1` + `data-types-reference.md:281` |
| `f7abccd` (#203) | [27327258790](https://github.com/velt-js/docs/actions/runs/27327258790) | precheck on `metadata.json:1` |

### Root cause — patch generation base ≠ application base

- `update-skill` checks out `agent-skills` with **no `ref:`** → defaults to **`main`**, then builds the patch via `git diff` against main.
- `validate-and-pr` checks out main, then (because an open `skills-sync` PR exists) `git checkout`s the **accumulator branch** (`skills-sync/cd7651e`) and runs `apply-patches.sh` with a strict `git apply --index --check`.
- The accumulator branch already bumped `metadata.json:1` (self-hosting 1.0.5→1.0.6, rest-apis 1.0.2→1.0.3) on prior runs, so a main-based patch's context no longer matches → precheck aborts. The longer the PR stays open, the more same-file syncs fail.

## The fix

1. **Generate against the application base.** The `plan` job resolves `base_ref` = the open `skills-sync` PR's branch (else `main`) and exposes it as a job output; `update-skill` checks out `agent-skills` at `base_ref`. Patches are now built against the exact tree they are applied onto — so they apply cleanly **and** every subsequent docs commit accumulates onto the open PR instead of failing.
2. **`git apply --3way`** in `apply-patches.sh` as a safety net for benign drift (still fails loudly on a genuine conflict — never silently skips).
3. **Never fail silently.** `validate-and-pr` now comments on the open `skills-sync` PR (or opens an issue) when a run fails, so a missed sync is always surfaced.

## Backfill (separate)

The 3 missed commits have already been backfilled onto the open accumulator PR — see [agent-skills#9](https://github.com/velt-js/agent-skills/pull/9) (self-hosting → v1.0.8, rest-apis → v1.0.4).

## Verification

- `bash -n scripts/skills-sync/apply-patches.sh` ✓ and workflow YAML parses ✓.
- After merge, re-dispatch `docs-sync-skills` (workflow_dispatch with `before_sha`/`target_sha`) for an already-synced commit and confirm the `update-skill` checkout ref == the accumulator branch and the apply step passes.

## Note / possible follow-up

`base_ref` is also a natural ref for the `plan` job's own `agent-skills` checkout (skill inventory) — left on `main` here to keep the change minimal; can follow up if planner routing ever needs to see branch-only skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
