### PR TITLE
feat: add v5.0.4 SDK release notes

### DIFF
--- a/release-notes/version-5/sdk-changelog.mdx
+++ b/release-notes/version-5/sdk-changelog.mdx
@@ -9,6 +9,28 @@ description: Release Notes of changes added to the core Velt SDK
 - `@veltdev/client`
 - `@veltdev/sdk`
 
+<Update label="5.0.4" description="June 19, 2026">
+
+### New Features
+
+- [**Self-Host Data**]: Resolver endpoint `headers` now accept an async function `() => Promise<Record<string, string>>` that is evaluated on every request — including each retry — so short-lived tokens are always fresh. A new optional `credentials` field (`'include' | 'same-origin' | 'omit'`) on `ResolverEndpointConfig` is forwarded to `fetch()`, enabling cookie/session auth on cross-origin resolver endpoints. Applies to all endpoint-based resolvers: comment, recorder, reaction, activity, notification, attachment, and user-permission. [Learn more →](/self-host-data/overview)
+
+- [**Self-Host Data**]: New opt-in `additionalSaveEvents` field on `ResolverConfig` lets you receive non-core annotation-level lifecycle events on the existing comment save endpoint — including status change, priority change, assign, approve, reactions, and subscription events. The new `CommentResolverSaveEvent` enum defines 14 supported event values. Disabled by default; existing behavior is unchanged. [Learn more →](/self-host-data/comments)
+
+- [**Self-Host Data**]: `SaveCommentResolverRequest` gains a new optional `targetComment` field containing the resolved `PartialComment` for the action target, so your backend no longer needs to re-derive it from `commentId` by scanning the annotation payload. [Learn more →](/self-host-data/comments)
+
+### API Changes
+
+- [**Comments**]: `CommentAnnotationVisibilityConfig` gains `organizationIds?: string[]`, matching the `CommentVisibilityConfig.organizationIds` field introduced in v5.0.3 for multi-org visibility. Reading `annotation.visibilityConfig.organizationIds` is now correctly typed.
+
+- [**Self-Host Data**]: The `event` field on `SaveCommentResolverRequest` (and `eventType` on `PartialCommentAnnotationResult`) is now typed as `ResolverActions | CommentResolverSaveEvent`, reflecting that non-core events delivered via `additionalSaveEvents` can also appear on this field.
+
+### Bug Fixes
+
+- [**Comments**]: Fixed an issue where the author's `userId` was not always included in `visibilityConfig.userIds` for private comments (`organizationPrivate` or `restricted`), which could cause the author to be filtered out on the REST read path. All five write paths (`addComment`, `saveComment`, `updateVisibility`, `addCommentAnnotation`, and the V2 composer path) now consistently include the author.
+
+</Update>
+
 <Update label="5.0.2" description="June 17, 2026">
 
 ### Bug Fixes


### PR DESCRIPTION
## Summary

Syncs the `v5.0.4` release notes from `snippyly/internal-release-notes` (PR #3, merged June 19, 2026) into `release-notes/version-5/sdk-changelog.mdx`.

### Changes in v5.0.4

**New Features**
- **Self-Host Data**: Resolver endpoint `headers` now accept an async function `() => Promise<Record<string, string>>` evaluated on every request (including each retry), so short-lived tokens stay fresh. New optional `credentials` field on `ResolverEndpointConfig` supports cookie/session auth on cross-origin endpoints. Applies to all resolvers: comment, recorder, reaction, activity, notification, attachment, user-permission.
- **Self-Host Data**: New opt-in `additionalSaveEvents` on `ResolverConfig` delivers non-core annotation lifecycle events (status change, priority change, assign, approve, reactions, subscriptions) to the existing save endpoint. New `CommentResolverSaveEvent` enum with 14 values. Off by default.
- **Self-Host Data**: `SaveCommentResolverRequest` gains a `targetComment?: PartialComment` field — the resolved comment for the action target, so backends no longer need to derive it from `commentId`.

**API Changes**
- **Comments**: `CommentAnnotationVisibilityConfig` gains `organizationIds?: string[]` to match `CommentVisibilityConfig.organizationIds` (introduced in v5.0.3 for multi-org visibility).
- **Self-Host Data**: `SaveCommentResolverRequest.event` (and `PartialCommentAnnotationResult.eventType`) widened from `ResolverActions` to `ResolverActions | CommentResolverSaveEvent`.

**Bug Fixes**
- **Comments**: Fixed `visibilityConfig.userIds` not always including the comment author for private comments (`organizationPrivate` / `restricted`), which could cause the author to be filtered out on the REST read path. All five write paths are now consistent.

## Source

- Internal PR: `snippyly/internal-release-notes#3` — `release-notes-v5.0.4 → main`
- Commit: `d89f33ed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0131oa5qK93x7mEpV76xk1Qa)_