### PR TITLE
docs: add Python SDK v0.1.14 release notes (resolver auth + comment save extensions)

### DIFF
--- a/release-notes/version-5/velt-py-changelog.mdx
+++ b/release-notes/version-5/velt-py-changelog.mdx
@@ -6,6 +6,18 @@ description: Release notes for the velt-py Python SDK for self-hosting
 ### Libraries
 - `velt-py`
 
+<Update label="Python SDK (velt-py) v0.1.14" description="June 19, 2026">
+
+### New Features
+
+- [**Self Hosting**]: New `sdk.selfHosting.verifyToken(headers=..., token=...)` helper authenticates the credential the Velt frontend forwards to your resolver endpoints. Opt-in via a `resolver_auth` config block, fail-closed, and returns a structured `VerifyTokenResult` (fields: `verified`, `claims`, `error`, `errorCode`). Supports a built-in JWT/JWKS verifier (HS256/RS256/ES256 with algorithm pinning, HTTPS-only JWKS, claim enforcement, and clock-skew leeway) and a custom-callback escape hatch. Install `pip install 'velt-py[auth]'` to enable the built-in verifier. [Learn more →](/backend-sdks/python)
+
+- [**Self Hosting**]: New `CommentResolverSaveEvent` enum covers 14 additional save events the Velt frontend can emit to your resolver via `ResolverConfig.additionalSaveEvents`: `STATUS_CHANGE`, `PRIORITY_CHANGE`, `ASSIGN`, `ACCESS_MODE_CHANGE`, `CUSTOM_LIST_CHANGE`, `APPROVE`, `ACCEPT`, `REJECT`, `SUGGESTION_ACCEPT`, `SUGGESTION_REJECT`, `REACTION_ADD`, `REACTION_DELETE`, `SUBSCRIBE`, `UNSUBSCRIBE`. All changes are additive and backward-compatible — existing `ResolverActions` values parse identically. [Learn more →](/backend-sdks/python)
+
+- [**Self Hosting**]: `SaveCommentResolverRequest` gains a new optional `targetComment: Optional[PartialComment]` field carrying the comment the action targeted, resolved by the frontend from `commentId`. It is request context for your handler only — `saveComments` never persists it. [Learn more →](/backend-sdks/python)
+
+</Update>
+
 <Update label="Python SDK (velt-py) v0.1.12" description="June 16, 2026">
 
 ### Bug Fixes


### PR DESCRIPTION
## Summary

Synced from [`snippyly/internal-release-notes` PR #4](https://github.com/snippyly/internal-release-notes/pull/4) (`release-notes-py-v0.1.14` → `main`).

Adds a new `<Update>` block for **Python SDK (velt-py) v0.1.14** (released June 19, 2026) to `release-notes/version-5/velt-py-changelog.mdx`.

### What's new in v0.1.14

- **Resolver token-verify helper** (`sdk.selfHosting.verifyToken`): Opt-in, fail-closed auth helper that verifies the credential the Velt frontend forwards to resolver endpoints. Supports built-in JWT/JWKS verification (HS256/RS256/ES256, algorithm pinning, HTTPS-only JWKS) and a custom-callback escape hatch. New optional extra: `pip install 'velt-py[auth]'`. New public types: `VerifyTokenResult`, `ResolverAuthService`.

- **`CommentResolverSaveEvent` enum**: 14 new save events the frontend can emit to resolvers (`STATUS_CHANGE`, `PRIORITY_CHANGE`, `ASSIGN`, `ACCESS_MODE_CHANGE`, `CUSTOM_LIST_CHANGE`, `APPROVE`, `ACCEPT`, `REJECT`, `SUGGESTION_ACCEPT`, `SUGGESTION_REJECT`, `REACTION_ADD`, `REACTION_DELETE`, `SUBSCRIBE`, `UNSUBSCRIBE`). Fully additive — existing `ResolverActions` values unchanged.

- **`SaveCommentResolverRequest.targetComment`**: New optional `PartialComment` field carrying the comment the action targeted. Handler context only — never persisted.

### Files changed

- `release-notes/version-5/velt-py-changelog.mdx` — prepended v0.1.14 `<Update>` block; all existing entries unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PhfPpxWe3ReZN4WCDpqbPj)_