### PR TITLE
docs: add velt-node-sdk v1.0.7 release notes

### DIFF
--- a/release-notes/version-5/velt-node-changelog.mdx
+++ b/release-notes/version-5/velt-node-changelog.mdx
@@ -7,6 +7,18 @@ description: Release Notes of changes added to the Velt Node.js/TypeScript SDK (
 ### Libraries
 - `@veltdev/node`
 
+<Update label="1.0.7" description="June 19, 2026">
+
+### New Features
+
+- **`CommentResolverSaveEvent` enum**: 14 new opt-in comment save events for the self-hosting `save` resolver endpoint — covering status change, priority change, assign, access mode change, custom list change, approve, accept, reject, suggestion accept/reject, comment-level reaction add/delete, and subscribe/unsubscribe. The Velt frontend SDK can send these via `ResolverConfig.additionalSaveEvents`. Fully additive; existing `save` resolver handlers are unaffected. [Learn more →](/backend-sdks/node#comment-resolver-save-events)
+
+- **`targetComment` on `SaveCommentResolverRequest`**: New optional `targetComment?: PartialComment` field providing the comment the action occurred on (resolved by the frontend from `commentId`). Available as request context in your handler; never persisted by `saveComments`. Fully additive. [Learn more →](/backend-sdks/node#comment-resolver-save-events)
+
+- **`sdk.selfHosting.verifyToken`**: New database-free, fail-closed helper to verify the bearer token the Velt frontend forwards to endpoint-based resolvers. Supports built-in JWT/JWKS verification via the optional `jose` peer dependency (`npm install jose`) and custom async callbacks. Always returns `{ verified: boolean, claims?, error?, errorCode? }` — never throws. Enforces `alg=none` rejection, algorithm-family separation, HTTPS-only JWKS fetching, and a URL-keyed 5-minute TTL cache by default. [Learn more →](/backend-sdks/node#verify-token)
+
+</Update>
+
 <Update label="1.0.5" description="June 16, 2026">
 
 ### Breaking Changes


### PR DESCRIPTION
## Summary

Syncs the `@veltdev/node` v1.0.7 release notes from [`snippyly/internal-release-notes` PR #5](https://github.com/snippyly/internal-release-notes/pull/5) (merged June 19, 2026) into the public docs changelog.

### Changes

**File updated:** `release-notes/version-5/velt-node-changelog.mdx`

New `<Update label="1.0.7" description="June 19, 2026">` entry added with three items:

1. **`CommentResolverSaveEvent` enum** — 14 new opt-in comment save events for the self-hosting `save` resolver endpoint (status change, priority change, assign, access mode change, custom list change, approve, accept, reject, suggestion accept/reject, comment-level reaction add/delete, subscribe/unsubscribe). Frontend sends these via `ResolverConfig.additionalSaveEvents`. Fully additive.

2. **`targetComment` on `SaveCommentResolverRequest`** — New optional `targetComment?: PartialComment` field providing request context (the comment the action occurred on). Never persisted by `saveComments`. Fully additive.

3. **`sdk.selfHosting.verifyToken`** — New database-free, fail-closed helper verifying the bearer token the Velt frontend forwards to endpoint-based resolvers. Supports built-in JWT/JWKS (via optional `jose` peer) and custom callbacks. Enforces `alg=none` rejection, algorithm-family separation, HTTPS-only JWKS, and a URL-keyed 5-minute TTL cache.

## Source

- Internal PR: [snippyly/internal-release-notes#5](https://github.com/snippyly/internal-release-notes/pull/5)
- Internal release notes file: `release-notes/velt-node-sdk/v1.0.7.md`
- Release date: June 19, 2026

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lf36zhfGe9gDxXbE1cwe5L)_