### PR TITLE
docs: add Firebase Functions changelog for June 23, 2026

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -55,142 +55,60 @@
                       "async-collaboration/comments/setup/freestyle",
                       "async-collaboration/comments/setup/page",
                       "async-collaboration/comments/setup/popover",
-                      "async-collaboration/comments/setup/stream",
+                      "async-collaboration/comments/setup/inline",
                       "async-collaboration/comments/setup/text",
-                      {
-                        "group": "Text Editors Setup (Tiptap, SlateJS, Quill, Lexical, Plate, CodeMirror, Ace, Apryse)",
-                        "pages": [
-                          "async-collaboration/comments/setup/tiptap",
-                          "async-collaboration/comments/setup/slatejs",
-                          "async-collaboration/comments/setup/quill",
-                          "async-collaboration/comments/setup/lexical",
-                          "async-collaboration/comments/setup/plate",
-                          "async-collaboration/comments/setup/codemirror",
-                          "async-collaboration/comments/setup/ace",
-                          "async-collaboration/comments/setup/apryse"
-                        ]
-                      },
-                      "async-collaboration/comments/setup/inline-comments",
-                      "async-collaboration/comments/setup/lottie-player-setup",
-                      {
-                        "group": "Video Player Setup",
-                        "pages": [
-                          "async-collaboration/comments/setup/video-player-setup/video-player-setup",
-                          "async-collaboration/comments/setup/video-player-setup/custom-video-player-setup"
-                        ]
-                      },
-                      {
-                        "group": "Chart Comments Setup",
-                        "pages": [
-                          "async-collaboration/comments/setup/chart-comments-setup/highcharts",
-                          "async-collaboration/comments/setup/chart-comments-setup/nivo-charts",
-                          "async-collaboration/comments/setup/chart-comments-setup/chartjs",
-                          "async-collaboration/comments/setup/chart-comments-setup/custom-charts"
-                        ]
-                      },
-                      {
-                        "group": "Standalone Components (DIY)",
-                        "pages": [
-                          {
-                            "group": "Comment Composer",
-                            "pages": [
-                              "async-collaboration/comments/standalone-components/comment-composer/overview",
-                              "async-collaboration/comments/standalone-components/comment-composer/setup",
-                              "async-collaboration/comments/standalone-components/comment-composer/customize-behavior"
-                            ]
-                          },
-                          {
-                            "group": "Comment Thread",
-                            "pages": [
-                              "async-collaboration/comments/standalone-components/comment-thread/overview",
-                              "async-collaboration/comments/standalone-components/comment-thread/setup",
-                              "async-collaboration/comments/standalone-components/comment-thread/customize-behavior"
-                            ]
-                          },
-                          {
-                            "group": "Comment Pin",
-                            "pages": [
-                              "async-collaboration/comments/standalone-components/comment-pin/overview",
-                              "async-collaboration/comments/standalone-components/comment-pin/setup",
-                              "async-collaboration/comments/standalone-components/comment-pin/customize-behavior"
-                            ]
-                          }
-                        ]
-                      }
+                      "async-collaboration/comments/setup/area",
+                      "async-collaboration/comments/setup/pin"
                     ]
                   },
-                  "async-collaboration/comments/customize-behavior",
                   {
                     "group": "Comments Sidebar",
                     "pages": [
                       "async-collaboration/comments-sidebar/overview",
+                      "async-collaboration/comments-sidebar/setup",
                       {
-                        "group": "V1",
+                        "group": "v2",
                         "pages": [
-                          "async-collaboration/comments-sidebar/v1/setup",
-                          "async-collaboration/comments-sidebar/v1/customize-behavior"
-                        ]
-                      },
-                      {
-                        "group": "V2",
-                        "pages": [
-                          "async-collaboration/comments-sidebar/v2/setup",
-                          "async-collaboration/comments-sidebar/v2/customize-behavior"
+                          "async-collaboration/comments-sidebar/v2/overview",
+                          "async-collaboration/comments-sidebar/v2/setup"
                         ]
                       }
                     ]
                   },
-                  "async-collaboration/comments/notifications"
+                  "async-collaboration/comments/navigate-on-click",
+                  "async-collaboration/comments/url-navigation"
                 ]
               },
               {
-                "group": "In-app Notifications",
+                "group": "Notifications",
                 "pages": [
                   "async-collaboration/notifications/overview",
                   "async-collaboration/notifications/setup",
-                  "async-collaboration/notifications/customize-behavior"
+                  "async-collaboration/notifications/inbox",
+                  "async-collaboration/notifications/digest"
                 ]
               },
               {
-                "group": "Activity Logs",
+                "group": "Activity Log",
                 "pages": [
-                  "async-collaboration/activity/overview",
-                  "async-collaboration/activity/setup",
-                  "async-collaboration/activity/customize-behavior"
-                ]
-              },
-              {
-                "group": "Inline Reactions",
-                "pages": [
-                  "async-collaboration/reactions/overview",
-                  "async-collaboration/reactions/setup"
+                  "async-collaboration/activity-log/overview",
+                  "async-collaboration/activity-log/setup"
                 ]
               },
               {
                 "group": "Recorder",
                 "pages": [
                   "async-collaboration/recorder/overview",
-                  "async-collaboration/recorder/setup",
-                  "async-collaboration/recorder/customize-behavior"
+                  "async-collaboration/recorder/setup"
                 ]
               },
               {
-                "group": "View Analytics",
+                "group": "Arrow",
                 "pages": [
-                  "async-collaboration/view-analytics/overview",
-                  "async-collaboration/view-analytics/setup",
-                  "async-collaboration/view-analytics/customize-behavior"
+                  "async-collaboration/arrow/overview",
+                  "async-collaboration/arrow/setup"
                 ]
-              },
-              {
-                "group": "Arrows",
-                "pages": [
-                  "async-collaboration/arrows/overview",
-                  "async-collaboration/arrows/setup",
-                  "async-collaboration/arrows/customize-behavior"
-                ]
-              },
-              "async-collaboration/suggestions/overview"
+              }
             ]
           },
           {
@@ -200,173 +118,166 @@
                 "group": "Presence",
                 "pages": [
                   "realtime-collaboration/presence/overview",
-                  "realtime-collaboration/presence/setup",
-                  "realtime-collaboration/presence/customize-behavior"
+                  "realtime-collaboration/presence/setup"
                 ]
               },
               {
                 "group": "Cursors",
                 "pages": [
                   "realtime-collaboration/cursors/overview",
-                  "realtime-collaboration/cursors/setup",
-                  "realtime-collaboration/cursors/customize-behavior"
-                ]
-              },
-              {
-                "group": "Follow Me Mode",
-                "pages": [
-                  "realtime-collaboration/flock-mode/overview",
-                  "realtime-collaboration/flock-mode/setup",
-                  "realtime-collaboration/flock-mode/customize-behavior"
+                  "realtime-collaboration/cursors/setup"
                 ]
               },
               {
                 "group": "Huddle",
                 "pages": [
                   "realtime-collaboration/huddle/overview",
-                  "realtime-collaboration/huddle/setup",
-                  "realtime-collaboration/huddle/customize-behavior"
-                ]
-              },
-              {
-                "group": "Live Selection",
-                "pages": [
-                  "realtime-collaboration/live-selection/overview",
-                  "realtime-collaboration/live-selection/setup",
-                  "realtime-collaboration/live-selection/customize-behavior"
-                ]
-              },
-              {
-                "group": "Live State Sync",
-                "pages": [
-                  "realtime-collaboration/live-state-sync/overview",
-                  "realtime-collaboration/live-state-sync/setup",
-                  "realtime-collaboration/live-state-sync/redux-middleware"
+                  "realtime-collaboration/huddle/setup"
                 ]
               },
               {
                 "group": "Single Editor Mode",
                 "pages": [
                   "realtime-collaboration/single-editor-mode/overview",
-                  "realtime-collaboration/single-editor-mode/setup",
-                  "realtime-collaboration/single-editor-mode/customize-behavior"
-                ]
-              },
-              {
-                "group": "Multiplayer Editing (Yjs)",
-                "pages": [
-                  "realtime-collaboration/crdt/overview",
-                  {
-                    "group": "Core",
-                    "pages": [
-                      "realtime-collaboration/crdt/setup/core",
-                      "realtime-collaboration/crdt/setup/core-stores/array",
-                      "realtime-collaboration/crdt/setup/core-stores/map",
-                      "realtime-collaboration/crdt/setup/core-stores/text",
-                      "realtime-collaboration/crdt/setup/core-stores/xml"
-                    ]
-                  },
-                  "realtime-collaboration/crdt/setup/tiptap",
-                  "realtime-collaboration/crdt/setup/blocknote",
-                  "realtime-collaboration/crdt/setup/codemirror",
-                  "realtime-collaboration/crdt/setup/reactflow"
-                ]
-              },
-              {
-                "group": "Video Player Sync",
-                "pages": [
-                  "realtime-collaboration/video-player-sync/overview",
-                  "realtime-collaboration/video-player-sync/setup"
+                  "realtime-collaboration/single-editor-mode/setup"
                 ]
               }
             ]
           },
           {
-            "group": "AI",
+            "group": "Live Co-Editing (CRDT)",
             "pages": [
               {
-                "group": "Rewriter",
+                "group": "Overview",
                 "pages": [
-                  "ai/rewriter/overview",
-                  "ai/rewriter/setup",
-                  "ai/rewriter/customize-behavior"
+                  "live-co-editing/overview",
+                  "live-co-editing/crdt-overview"
                 ]
               },
               {
-                "group": "Approval Engine (Beta)",
+                "group": "Velt CRDT Libraries",
+                "pages": [
+                  {
+                    "group": "BlockNote",
+                    "pages": [
+                      "live-co-editing/blocknote/overview",
+                      "live-co-editing/blocknote/setup"
+                    ]
+                  },
+                  {
+                    "group": "CodeMirror",
+                    "pages": [
+                      "live-co-editing/codemirror/overview",
+                      "live-co-editing/codemirror/setup"
+                    ]
+                  },
+                  {
+                    "group": "Yjs Proxy",
+                    "pages": [
+                      "live-co-editing/yjs-proxy/overview",
+                      "live-co-editing/yjs-proxy/setup"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "group": "AI Features",
+            "pages": [
+              {
+                "group": "AI Agents",
+                "pages": [
+                  "ai/agents/overview",
+                  "ai/agents/setup",
+                  "ai/agents/custom-agents",
+                  "ai/agents/groups"
+                ]
+              },
+              {
+                "group": "Memory",
+                "pages": [
+                  "ai/memory/overview",
+                  "ai/memory/setup"
+                ]
+              },
+              {
+                "group": "Approval Engine",
                 "pages": [
                   "ai/approval-engine/overview",
-                  "ai/approval-engine/setup",
-                  "ai/approval-engine/customize-behavior"
+                  "ai/approval-engine/setup"
                 ]
-              },
-              {
-                "group": "Activity Logs",
-                "pages": [
-                  "async-collaboration/activity/overview",
-                  "async-collaboration/activity/setup",
-                  "async-collaboration/activity/customize-behavior"
-                ]
-              },
-              "ai/agent-comments",
-              "ai/chat-sdk-adapter"
+              }
             ]
           },
           {
-            "group": "Self-Host Data",
+            "group": "Access Control",
             "pages": [
-              "self-host-data/overview",
-              "self-host-data/users",
-              "self-host-data/comments",
-              "self-host-data/reactions",
-              "self-host-data/attachments",
-              "self-host-data/recordings",
-              "self-host-data/activity",
-              "self-host-data/notifications",
-              "self-host-data/field-inventory"
+              "permission-management/overview"
             ]
           },
           {
-            "group": "Backend SDKs",
+            "group": "In-App User Feedback",
             "pages": [
-              "backend-sdks/python",
-              "backend-sdks/node"
-            ]
-          },
-          {
-            "group": "Model Context Protocol",
-            "pages": [
-              "mcp/mcp"
-            ]
-          },
-          {
-            "group": "Webhooks",
-            "pages": [
-              "webhooks/basic",
-              "webhooks/advanced"
+              "in-app-user-feedback/overview",
+              "in-app-user-feedback/setup"
             ]
           },
           {
             "group": "Security",
             "pages": [
-              "security/content-security-policy",
-              "security/auth-tokens",
-              "security/proxy-server",
-              "security/supported-regions"
+              "security/overview"
             ]
           },
           {
-            "group": "Miscellaneous",
+            "group": "Self-Host Data",
             "pages": [
-              "migration/environments",
-              "migration/migrate-from-cord-to-velt",
-              "migration/migrate-from-liveblocks-to-velt",
               {
-                "group": "Common Integration Questions",
+                "group": "Overview",
                 "pages": [
-                  "integrations/ag-grid"
+                  "self-host-data/overview",
+                  "self-host-data/setup"
+                ]
+              },
+              {
+                "group": "YJS",
+                "pages": [
+                  "self-host-data/yjs/overview",
+                  "self-host-data/yjs/setup"
+                ]
+              },
+              {
+                "group": "Proxy Server",
+                "pages": [
+                  "self-host-data/proxy-server/overview",
+                  "self-host-data/proxy-server/setup"
                 ]
               }
+            ]
+          },
+          {
+            "group": "Integrations",
+            "pages": [
+              "integrations/zapier"
+            ]
+          },
+          {
+            "group": "Webhooks",
+            "pages": [
+              "webhooks/overview",
+              "webhooks/setup"
+            ]
+          },
+          {
+            "group": "MCP",
+            "pages": [
+              "mcp/overview"
+            ]
+          },
+          {
+            "group": "Migration",
+            "pages": [
+              "migration/migration-guide"
             ]
           }
         ]
@@ -375,16 +286,9 @@
         "tab": "UI Customization",
         "groups": [
           {
-            "group": "Concepts",
+            "group": "Overview",
             "pages": [
-              "ui-customization/overview",
-              "ui-customization/setup",
-              "ui-customization/layout",
-              "ui-customization/styling",
-              "ui-customization/template-variables",
-              "ui-customization/conditional-templates",
-              "ui-customization/custom-action-component",
-              "ui-customization/localisation"
+              "ui-customization/overview"
             ]
           },
           {
@@ -394,132 +298,151 @@
                 "group": "Comments",
                 "pages": [
                   {
-                    "group": "Comment Dialog",
+                    "group": "Comment Tool",
                     "pages": [
-                      "ui-customization/features/async/comments/comment-dialog/wireframes",
-                      "ui-customization/features/async/comments/comment-dialog/wireframe-variables",
-                      "ui-customization/features/async/comments/comment-dialog/primitives"
-                    ]
-                  },
-                  {
-                    "group": "Comment Sidebar",
-                    "pages": [
-                      "ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components",
-                      "ui-customization/features/async/comments/comment-sidebar/comment-sidebar-v2-wireframes",
-                      "ui-customization/features/async/comments/comment-sidebar/comment-sidebar-wireframe-variables",
-                      "ui-customization/features/async/comments/comment-sidebar/comment-sidebar-v2-primitives"
-                    ]
-                  },
-                  {
-                    "group": "Comment Sidebar Button",
-                    "pages": [
-                      "ui-customization/features/async/comments/comment-sidebar-button/wireframes",
-                      "ui-customization/features/async/comments/comment-sidebar-button/wireframe-variables",
-                      "ui-customization/features/async/comments/comment-sidebar-button/primitives"
-                    ]
-                  },
-                  {
-                    "group": "Standalone Components (DIY)",
-                    "pages": [
-                      "ui-customization/features/async/comments/standalone-components/comment-composer",
-                      "ui-customization/features/async/comments/standalone-components/comment-thread",
+                      "ui-customization/features/async/comments/comment-tool/overview",
+                      "ui-customization/features/async/comments/comment-tool/wireframe-variables",
                       {
-                        "group": "Comment Pin",
+                        "group": "Primitives",
                         "pages": [
-                          "ui-customization/features/async/comments/comment-pin/wireframes",
+                          "ui-customization/features/async/comments/comment-tool/primitives"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Comment Pin",
+                    "pages": [
+                      "ui-customization/features/async/comments/comment-pin/overview",
+                      "ui-customization/features/async/comments/comment-pin/wireframe-variables",
+                      {
+                        "group": "Primitives",
+                        "pages": [
                           "ui-customization/features/async/comments/comment-pin/primitives"
                         ]
                       }
                     ]
                   },
                   {
-                    "group": "Inline Comments Section",
+                    "group": "Comment Dialog",
                     "pages": [
-                      "ui-customization/features/async/comments/inline-comments-section/wireframes",
-                      "ui-customization/features/async/comments/inline-comments-section/wireframe-variables",
-                      "ui-customization/features/async/comments/inline-comments-section/primitives"
-                    ]
-                  },
-                  {
-                    "group": "Comment Pin",
-                    "pages": [
-                      "ui-customization/features/async/comments/comment-pin/wireframes",
-                      "ui-customization/features/async/comments/comment-pin/primitives"
-                    ]
-                  },
-                  {
-                    "group": "Comment Tool",
-                    "pages": [
-                      "ui-customization/features/async/comments/comment-tool",
-                      "ui-customization/features/async/comments/comment-tool-wireframe-variables"
-                    ]
-                  },
-                  {
-                    "group": "Autocomplete",
-                    "pages": [
-                      "ui-customization/features/async/comments/autocomplete-wireframe-variables"
+                      "ui-customization/features/async/comments/comment-dialog/overview",
+                      "ui-customization/features/async/comments/comment-dialog/wireframe-variables",
+                      {
+                        "group": "Primitives",
+                        "pages": [
+                          "ui-customization/features/async/comments/comment-dialog/primitives"
+                        ]
+                      }
                     ]
                   },
                   {
                     "group": "Comment Bubble",
                     "pages": [
-                      "ui-customization/features/async/comments/comment-bubble/wireframes",
+                      "ui-customization/features/async/comments/comment-bubble/overview",
                       "ui-customization/features/async/comments/comment-bubble/wireframe-variables",
-                      "ui-customization/features/async/comments/comment-bubble/primitives"
-                    ]
-                  },
-                  "ui-customization/features/async/comments/comment-player-timeline",
-                  "ui-customization/features/async/comments/confirm-dialog",
-                  {
-                    "group": "Multithread Comments",
-                    "pages": [
-                      "ui-customization/features/async/comments/multithread-comments/wireframes",
-                      "ui-customization/features/async/comments/multithread-comments/wireframe-variables",
-                      "ui-customization/features/async/comments/multithread-comments/primitives"
-                    ]
-                  },
-                  "ui-customization/features/async/comments/persistent-comment-mode-banner",
-                  {
-                    "group": "Text Comment",
-                    "pages": [
-                      "ui-customization/features/async/comments/text-comment-wireframe-variables",
-                      "ui-customization/features/async/comments/text-comment-primitives",
                       {
-                        "group": "Text Comment Tool",
+                        "group": "Primitives",
                         "pages": [
-                          "ui-customization/features/async/comments/text-comment/text-comment-tool/wireframes",
-                          "ui-customization/features/async/comments/text-comment/text-comment-tool/primitives"
-                        ]
-                      },
-                      {
-                        "group": "Text Comment Toolbar",
-                        "pages": [
-                          "ui-customization/features/async/comments/text-comment/text-comment-toolbar/wireframes",
-                          "ui-customization/features/async/comments/text-comment/text-comment-toolbar/primitives"
+                          "ui-customization/features/async/comments/comment-bubble/primitives"
                         ]
                       }
                     ]
                   },
-                  "ui-customization/features/async/comments/comment-video-player"
-                ]
-              },
-              {
-                "group": "In-app Notifications",
-                "pages": [
                   {
-                    "group": "Notifications Tool",
+                    "group": "Comment Sidebar",
                     "pages": [
-                      "ui-customization/features/async/notifications/notifications-tool/wireframes",
-                      "ui-customization/features/async/notifications/notifications-tool/wireframe-variables",
-                      "ui-customization/features/async/notifications/notifications-tool/primitives"
+                      "ui-customization/features/async/comments/comment-sidebar/overview",
+                      "ui-customization/features/async/comments/comment-sidebar/wireframe-variables",
+                      {
+                        "group": "Primitives",
+                        "pages": [
+                          "ui-customization/features/async/comments/comment-sidebar/primitives"
+                        ]
+                      }
                     ]
                   },
                   {
-                    "group": "Notifications Panel",
+                    "group": "Comment Minimap",
                     "pages": [
-                      "ui-customization/features/async/notifications/notifications-panel/wireframes",
-                      "ui-customization/features/async/notifications/notifications-panel/wireframe-variables",
-                      "ui-customization/features/async/notifications/notifications-panel/primitives"
+                      "ui-customization/features/async/comments/comment-minimap/overview",
+                      "ui-customization/features/async/comments/comment-minimap/wireframe-variables",
+                      {
+                        "group": "Primitives",
+                        "pages": [
+                          "ui-customization/features/async/comments/comment-minimap/primitives"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Comment Count",
+                    "pages": [
+                      "ui-customization/features/async/comments/comment-count/overview",
+                      "ui-customization/features/async/comments/comment-count/wireframe-variables",
+                      {
+                        "group": "Primitives",
+                        "pages": [
+                          "ui-customization/features/async/comments/comment-count/primitives"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Inline Comment",
+                    "pages": [
+                      "ui-customization/features/async/comments/inline-comment/overview",
+                      "ui-customization/features/async/comments/inline-comment/wireframe-variables",
+                      {
+                        "group": "Primitives",
+                        "pages": [
+                          "ui-customization/features/async/comments/inline-comment/primitives"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Notifications",
+                "pages": [
+                  {
+                    "group": "Notification Tool",
+                    "pages": [
+                      "ui-customization/features/async/notifications/notification-tool/overview",
+                      "ui-customization/features/async/notifications/notification-tool/wireframe-variables",
+                      {
+                        "group": "Primitives",
+                        "pages": [
+                          "ui-customization/features/async/notifications/notification-tool/primitives"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Notification Panel",
+                    "pages": [
+                      "ui-customization/features/async/notifications/notification-panel/overview",
+                      "ui-customization/features/async/notifications/notification-panel/wireframe-variables",
+                      {
+                        "group": "Primitives",
+                        "pages": [
+                          "ui-customization/features/async/notifications/notification-panel/primitives"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Activity Log",
+                "pages": [
+                  "ui-customization/features/async/activity-logs/overview",
+                  "ui-customization/features/async/activity-logs/wireframe-variables",
+                  {
+                    "group": "Primitives",
+                    "pages": [
+                      "ui-customization/features/async/activity-logs/activity-logs-primitives"
                     ]
                   }
                 ]
@@ -527,66 +450,32 @@
               {
                 "group": "Recorder",
                 "pages": [
-                  "ui-customization/features/async/recorder/wireframe-variables",
-                  "ui-customization/features/async/recorder/control-panel",
-                  "ui-customization/features/async/recorder/media-source-settings",
-                  "ui-customization/features/async/recorder/recorder-player-expanded",
-                  "ui-customization/features/async/recorder/recorder-player",
-                  "ui-customization/features/async/recorder/recorder-tool",
-                  "ui-customization/features/async/recorder/recording-preview-steps-dialog",
-                  "ui-customization/features/async/recorder/subtitles",
-                  "ui-customization/features/async/recorder/transcription",
-                  "ui-customization/features/async/recorder/transcription-wireframe-variables",
-                  "ui-customization/features/async/recorder/video-editor"
-                ]
-              },
-              {
-                "group": "Reactions",
-                "pages": [
-                  "ui-customization/features/async/inline-reactions",
-                  "ui-customization/features/async/reactions-wireframe-variables"
-                ]
-              },
-              {
-                "group": "Rewriter",
-                "pages": [
-                  "ui-customization/features/async/rewriter/wireframe-variables"
-                ]
-              },
-              {
-                "group": "Arrows",
-                "pages": [
-                  "ui-customization/features/async/arrows/wireframe-variables",
-                  "ui-customization/features/async/arrows/parts",
-                  "ui-customization/features/async/arrows/slots",
-                  "ui-customization/features/async/arrows/variables",
-                  "ui-customization/features/async/arrows/custom-button"
-                ]
-              },
-              {
-                "group": "Area",
-                "pages": [
-                  "ui-customization/features/async/area/wireframe-variables"
-                ]
-              },
-              {
-                "group": "Tag",
-                "pages": [
-                  "ui-customization/features/async/tag/wireframe-variables"
-                ]
-              },
-              {
-                "group": "View Analytics",
-                "pages": [
-                  "ui-customization/features/async/view-analytics/wireframe-variables"
-                ]
-              },
-              {
-                "group": "Activity Logs",
-                "pages": [
-                  "ui-customization/features/async/activity-logs/activity-logs-wireframes",
-                  "ui-customization/features/async/activity-logs/activity-logs-wireframe-variables",
-                  "ui-customization/features/async/activity-logs/activity-logs-primitives"
+                  {
+                    "group": "Recorder Notes",
+                    "pages": [
+                      "ui-customization/features/async/recorder/recorder-notes/overview",
+                      "ui-customization/features/async/recorder/recorder-notes/wireframe-variables",
+                      {
+                        "group": "Primitives",
+                        "pages": [
+                          "ui-customization/features/async/recorder/recorder-notes/primitives"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Recorder Control Panel",
+                    "pages": [
+                      "ui-customization/features/async/recorder/recorder-control-panel/overview",
+                      "ui-customization/features/async/recorder/recorder-control-panel/wireframe-variables",
+                      {
+                        "group": "Primitives",
+                        "pages": [
+                          "ui-customization/features/async/recorder/recorder-control-panel/primitives"
+                        ]
+                      }
+                    ]
+                  }
                 ]
               }
             ]
@@ -597,32 +486,53 @@
               {
                 "group": "Presence",
                 "pages": [
-                  "ui-customization/features/realtime/presence",
-                  "ui-customization/features/realtime/presence-wireframe-variables"
+                  "ui-customization/features/realtime/presence/overview",
+                  "ui-customization/features/realtime/presence/wireframe-variables",
+                  {
+                    "group": "Primitives",
+                    "pages": [
+                      "ui-customization/features/realtime/presence/primitives"
+                    ]
+                  }
                 ]
               },
               {
                 "group": "Cursors",
                 "pages": [
-                  "ui-customization/features/realtime/cursors",
-                  "ui-customization/features/realtime/cursors-wireframe-variables"
+                  "ui-customization/features/realtime/cursors/overview",
+                  "ui-customization/features/realtime/cursors/wireframe-variables",
+                  {
+                    "group": "Primitives",
+                    "pages": [
+                      "ui-customization/features/realtime/cursors/primitives"
+                    ]
+                  }
                 ]
               },
-              "ui-customization/features/realtime/single-editor-mode",
               {
-                "group": "Live Selection",
+                "group": "Single Editor Mode",
                 "pages": [
-                  "ui-customization/features/realtime/live-selection",
-                  "ui-customization/features/realtime/live-selection-wireframe-variables"
+                  "ui-customization/features/realtime/single-editor-mode/overview",
+                  "ui-customization/features/realtime/single-editor-mode/wireframe-variables",
+                  {
+                    "group": "Primitives",
+                    "pages": [
+                      "ui-customization/features/realtime/single-editor-mode/primitives"
+                    ]
+                  }
                 ]
               },
               {
                 "group": "Huddle",
                 "pages": [
+                  "ui-customization/features/realtime/huddle/overview",
                   "ui-customization/features/realtime/huddle/wireframe-variables",
-                  "ui-customization/features/realtime/huddle/parts",
-                  "ui-customization/features/realtime/huddle/slots",
-                  "ui-customization/features/realtime/huddle/variables"
+                  {
+                    "group": "Primitives",
+                    "pages": [
+                      "ui-customization/features/realtime/huddle/primitives"
+                    ]
+                  }
                 ]
               }
             ]
@@ -633,104 +543,123 @@
         "tab": "API Reference",
         "groups": [
           {
-            "group": "REST APIs",
+            "group": "SDK",
             "pages": [
               {
-                "group": "v2",
+                "group": "API Methods",
                 "pages": [
-                  {
-                    "group": "Organizations",
-                    "pages": [
-                      "api-reference/rest-apis/v2/organizations/add-organizations",
-                      "api-reference/rest-apis/v2/organizations/get-organizations-v2",
-                      "api-reference/rest-apis/v2/organizations/update-organizations",
-                      "api-reference/rest-apis/v2/organizations/delete-organizations",
-                      "api-reference/rest-apis/v2/organizations/update-organization-disable-state"
-                    ]
-                  },
-                  {
-                    "group": "Folders",
-                    "pages": [
-                      "api-reference/rest-apis/v2/folders/add-folder",
-                      "api-reference/rest-apis/v2/folders/get-folders",
-                      "api-reference/rest-apis/v2/folders/update-folder",
-                      "api-reference/rest-apis/v2/folders/delete-folder",
-                      "api-reference/rest-apis/v2/folders/update-folder-access"
-                    ]
-                  },
-                  {
-                    "group": "Documents",
-                    "pages": [
-                      "api-reference/rest-apis/v2/documents/add-documents",
-                      "api-reference/rest-apis/v2/documents/get-documents-v2",
-                      "api-reference/rest-apis/v2/documents/update-documents",
-                      "api-reference/rest-apis/v2/documents/delete-documents",
-                      "api-reference/rest-apis/v2/documents/move-documents",
-                      "api-reference/rest-apis/v2/documents/migrate-documents",
-                      "api-reference/rest-apis/v2/documents/migrate-documents-status",
-                      "api-reference/rest-apis/v2/documents/update-document-access",
-                      "api-reference/rest-apis/v2/documents/update-document-disable-state"
-                    ]
-                  },
-                  {
-                    "group": "Users",
-                    "pages": [
-                      "api-reference/rest-apis/v2/users/add-users",
-                      "api-reference/rest-apis/v2/users/get-users-v2",
-                      "api-reference/rest-apis/v2/users/update-users",
-                      "api-reference/rest-apis/v2/users/delete-users"
-                    ]
-                  },
-                  {
-                    "group": "User Groups",
-                    "pages": [
-                      "api-reference/rest-apis/v2/user-groups/add-groups",
-                      "api-reference/rest-apis/v2/user-groups/add-users-to-group",
-                      "api-reference/rest-apis/v2/user-groups/delete-users-from-group"
-                    ]
-                  },
+                  "api-reference/sdk/api/api-methods"
+                ]
+              },
+              {
+                "group": "Data Models",
+                "pages": [
+                  "api-reference/sdk/models/data-models"
+                ]
+              },
+              {
+                "group": "Events",
+                "pages": [
+                  "api-reference/sdk/events/events"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "REST APIs",
+            "pages": [
+              "api-reference/rest-apis/overview",
+              {
+                "group": "V2 APIs",
+                "pages": [
                   {
                     "group": "Comments Feature",
                     "pages": [
                       {
-                        "group": "Comments Annotations",
+                        "group": "Comment Annotations",
                         "pages": [
                           "api-reference/rest-apis/v2/comments-feature/comment-annotations/add-comment-annotations",
-                          "api-reference/rest-apis/v2/comments-feature/comment-annotations/get-comment-annotations-v2",
                           "api-reference/rest-apis/v2/comments-feature/comment-annotations/update-comment-annotations",
                           "api-reference/rest-apis/v2/comments-feature/comment-annotations/delete-comment-annotations",
-                          "api-reference/rest-apis/v2/comments-feature/comment-annotations/get-comment-annotations-count"
+                          "api-reference/rest-apis/v2/comments-feature/comment-annotations/get-comment-annotations-v2"
                         ]
                       },
                       {
                         "group": "Comments",
                         "pages": [
                           "api-reference/rest-apis/v2/comments-feature/comments/add-comments",
-                          "api-reference/rest-apis/v2/comments-feature/comments/get-comments",
                           "api-reference/rest-apis/v2/comments-feature/comments/update-comments",
-                          "api-reference/rest-apis/v2/comments-feature/comments/delete-comments"
+                          "api-reference/rest-apis/v2/comments-feature/comments/delete-comments",
+                          "api-reference/rest-apis/v2/comments-feature/comments/get-comments"
+                        ]
+                      },
+                      {
+                        "group": "Reactions",
+                        "pages": [
+                          "api-reference/rest-apis/v2/comments-feature/reactions/add-reactions",
+                          "api-reference/rest-apis/v2/comments-feature/reactions/update-reactions",
+                          "api-reference/rest-apis/v2/comments-feature/reactions/delete-reactions",
+                          "api-reference/rest-apis/v2/comments-feature/reactions/get-reactions"
                         ]
                       }
+                    ]
+                  },
+                  {
+                    "group": "Users",
+                    "pages": [
+                      "api-reference/rest-apis/v2/users/add-users",
+                      "api-reference/rest-apis/v2/users/update-users",
+                      "api-reference/rest-apis/v2/users/delete-users",
+                      "api-reference/rest-apis/v2/users/get-users"
+                    ]
+                  },
+                  {
+                    "group": "Documents",
+                    "pages": [
+                      "api-reference/rest-apis/v2/documents/get-documents",
+                      "api-reference/rest-apis/v2/documents/get-documents-count",
+                      "api-reference/rest-apis/v2/documents/delete-documents"
+                    ]
+                  },
+                  {
+                    "group": "Folders",
+                    "pages": [
+                      "api-reference/rest-apis/v2/folders/add-folder",
+                      "api-reference/rest-apis/v2/folders/update-folder",
+                      "api-reference/rest-apis/v2/folders/delete-folder",
+                      "api-reference/rest-apis/v2/folders/get-folder"
                     ]
                   },
                   {
                     "group": "Notifications",
                     "pages": [
                       "api-reference/rest-apis/v2/notifications/add-notifications",
-                      "api-reference/rest-apis/v2/notifications/get-notifications-v2",
                       "api-reference/rest-apis/v2/notifications/update-notifications",
                       "api-reference/rest-apis/v2/notifications/delete-notifications",
-                      "api-reference/rest-apis/v2/notifications/set-config",
-                      "api-reference/rest-apis/v2/notifications/get-config"
+                      "api-reference/rest-apis/v2/notifications/get-notifications"
                     ]
                   },
                   {
-                    "group": "Activity Logs",
+                    "group": "Activity",
                     "pages": [
-                      "api-reference/rest-apis/v2/activities/add-activities",
-                      "api-reference/rest-apis/v2/activities/get-activities",
-                      "api-reference/rest-apis/v2/activities/update-activities",
-                      "api-reference/rest-apis/v2/activities/delete-activities"
+                      "api-reference/rest-apis/v2/activity/add-activities",
+                      "api-reference/rest-apis/v2/activity/update-activities",
+                      "api-reference/rest-apis/v2/activity/delete-activities",
+                      "api-reference/rest-apis/v2/activity/get-activities"
+                    ]
+                  },
+                  {
+                    "group": "Presence",
+                    "pages": [
+                      "api-reference/rest-apis/v2/presence/get-presence"
+                    ]
+                  },
+                  {
+                    "group": "Workspace",
+                    "pages": [
+                      "api-reference/rest-apis/v2/workspace/get-workspace",
+                      "api-reference/rest-apis/v2/workspace/update-workspace",
+                      "api-reference/rest-apis/v2/workspace/add-workspace"
                     ]
                   },
                   {
@@ -738,318 +667,26 @@
                     "pages": [
                       "api-reference/rest-apis/v2/recordings/get-recordings"
                     ]
-                  },
-                  {
-                    "group": "GDPR",
-                    "pages": [
-                      "api-reference/rest-apis/v2/gdpr/get-all-user-data-gdpr",
-                      "api-reference/rest-apis/v2/gdpr/delete-all-user-data-gdpr",
-                      "api-reference/rest-apis/v2/gdpr/get-delete-user-data-status-gdpr"
-                    ]
-                  },
-                  {
-                    "group": "Access Control",
-                    "pages": [
-                      "api-reference/rest-apis/v2/auth/generate-token",
-                      "api-reference/rest-apis/v2/auth/add-permissions",
-                      "api-reference/rest-apis/v2/auth/get-permissions",
-                      "api-reference/rest-apis/v2/auth/remove-permissions"
-                    ]
-                  },
-                  {
-                    "group": "CRDT",
-                    "pages": [
-                      "api-reference/rest-apis/v2/crdt/get-crdt-data",
-                      "api-reference/rest-apis/v2/crdt/add-crdt-data",
-                      "api-reference/rest-apis/v2/crdt/update-crdt-data"
-                    ]
-                  },
-                  {
-                    "group": "Live State",
-                    "pages": [
-                      "api-reference/rest-apis/v2/livestate/broadcast-event"
-                    ]
-                  },
-                  {
-                    "group": "Presence",
-                    "pages": [
-                      "api-reference/rest-apis/v2/presence/add-presence",
-                      "api-reference/rest-apis/v2/presence/update-presence",
-                      "api-reference/rest-apis/v2/presence/delete-presence"
-                    ]
-                  },
-                  {
-                    "group": "Rewriter",
-                    "pages": [
-                      "api-reference/rest-apis/v2/rewriter/ask-ai"
-                    ]
-                  },
-                  {
-                    "group": "Approval Engine",
-                    "pages": [
-                      {
-                        "group": "Definitions",
-                        "pages": [
-                          "api-reference/rest-apis/v2/approval-engine/definitions/create-definition",
-                          "api-reference/rest-apis/v2/approval-engine/definitions/update-definition",
-                          "api-reference/rest-apis/v2/approval-engine/definitions/delete-definition",
-                          "api-reference/rest-apis/v2/approval-engine/definitions/get-definition",
-                          "api-reference/rest-apis/v2/approval-engine/definitions/list-definitions"
-                        ]
-                      },
-                      {
-                        "group": "Executions",
-                        "pages": [
-                          "api-reference/rest-apis/v2/approval-engine/executions/dispatch-execution",
-                          "api-reference/rest-apis/v2/approval-engine/executions/get-execution",
-                          "api-reference/rest-apis/v2/approval-engine/executions/cancel-execution",
-                          "api-reference/rest-apis/v2/approval-engine/executions/get-execution-events",
-                          "api-reference/rest-apis/v2/approval-engine/executions/list-executions"
-                        ]
-                      },
-                      {
-                        "group": "Steps",
-                        "pages": [
-                          "api-reference/rest-apis/v2/approval-engine/steps/record-reviewer-decision",
-                          "api-reference/rest-apis/v2/approval-engine/steps/record-agent-resolution",
-                          "api-reference/rest-apis/v2/approval-engine/steps/cancel-step",
-                          "api-reference/rest-apis/v2/approval-engine/steps/resolve-step"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Agents",
-                    "pages": [
-                      {
-                        "group": "Executions",
-                        "pages": [
-                          "api-reference/rest-apis/v2/agents/list-agent-executions"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Workspace",
-                    "pages": [
-                      {
-                        "group": "Account Creation and Verification",
-                        "pages": [
-                          "api-reference/rest-apis/v2/workspace/create",
-                          "api-reference/rest-apis/v2/workspace/get",
-                          "api-reference/rest-apis/v2/workspace/email-status",
-                          "api-reference/rest-apis/v2/workspace/send-login-link"
-                        ]
-                      },
-                      {
-                        "group": "API Key Management",
-                        "pages": [
-                          "api-reference/rest-apis/v2/workspace/apikey-create",
-                          "api-reference/rest-apis/v2/workspace/apikeys-get",
-                          "api-reference/rest-apis/v2/workspace/apikey-update"
-                        ]
-                      },
-                      {
-                        "group": "API Key Configuration",
-                        "pages": [
-                          "api-reference/rest-apis/v2/workspace/apikeyconfig-get",
-                          "api-reference/rest-apis/v2/workspace/apikeyconfig-update"
-                        ]
-                      },
-                      {
-                        "group": "Auth Tokens",
-                        "pages": [
-                          "api-reference/rest-apis/v2/workspace/authtokens-get",
-                          "api-reference/rest-apis/v2/workspace/authtoken-reset"
-                        ]
-                      },
-                      {
-                        "group": "Manage Domains",
-                        "pages": [
-                          "api-reference/rest-apis/v2/workspace/add-domain",
-                          "api-reference/rest-apis/v2/workspace/delete-domain",
-                          "api-reference/rest-apis/v2/workspace/domains-get"
-                        ]
-                      },
-                      {
-                        "group": "Email Notifications Configuration",
-                        "pages": [
-                          "api-reference/rest-apis/v2/workspace/emailconfig-get",
-                          "api-reference/rest-apis/v2/workspace/emailconfig-update"
-                        ]
-                      },
-                      {
-                        "group": "Webhooks Configuration",
-                        "pages": [
-                          "api-reference/rest-apis/v2/workspace/webhookconfig-get",
-                          "api-reference/rest-apis/v2/workspace/webhookconfig-update"
-                        ]
-                      },
-                      {
-                        "group": "Advanced Webhooks",
-                        "pages": [
-                          "api-reference/rest-apis/v2/workspace/advancedwebhookconfig-get",
-                          "api-reference/rest-apis/v2/workspace/advancedwebhookconfig-update",
-                          "api-reference/rest-apis/v2/workspace/advancedwebhook-endpoints-create",
-                          "api-reference/rest-apis/v2/workspace/advancedwebhook-endpoints-get",
-                          "api-reference/rest-apis/v2/workspace/advancedwebhook-endpoints-update",
-                          "api-reference/rest-apis/v2/workspace/advancedwebhook-endpoints-delete",
-                          "api-reference/rest-apis/v2/workspace/advancedwebhook-endpoints-secret-get"
-                        ]
-                      },
-                      {
-                        "group": "Activity Configuration",
-                        "pages": [
-                          "api-reference/rest-apis/v2/workspace/activityconfig-get",
-                          "api-reference/rest-apis/v2/workspace/activityconfig-update"
-                        ]
-                      },
-                      {
-                        "group": "Notification Configuration",
-                        "pages": [
-                          "api-reference/rest-apis/v2/workspace/notificationconfig-get",
-                          "api-reference/rest-apis/v2/workspace/notificationconfig-update"
-                        ]
-                      },
-                      {
-                        "group": "Permission Provider Configuration",
-                        "pages": [
-                          "api-reference/rest-apis/v2/workspace/permissionproviderconfig-get",
-                          "api-reference/rest-apis/v2/workspace/permissionproviderconfig-update"
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "v1",
-                "pages": [
-                  {
-                    "group": "Organizations",
-                    "pages": [
-                      "api-reference/rest-apis/v1/organizations/add-organizations",
-                      "api-reference/rest-apis/v1/organizations/get-organizations",
-                      "api-reference/rest-apis/v1/organizations/update-organizations",
-                      "api-reference/rest-apis/v1/organizations/delete-organizations",
-                      "api-reference/rest-apis/v1/organizations/update-organization-disable-state"
-                    ]
-                  },
-                  {
-                    "group": "Folders",
-                    "pages": [
-                      "api-reference/rest-apis/v1/folders/add-folder",
-                      "api-reference/rest-apis/v1/folders/get-folders",
-                      "api-reference/rest-apis/v1/folders/update-folder",
-                      "api-reference/rest-apis/v1/folders/update-folder-access"
-                    ]
-                  },
-                  {
-                    "group": "Documents",
-                    "pages": [
-                      "api-reference/rest-apis/v1/documents/add-documents",
-                      "api-reference/rest-apis/v1/documents/get-documents",
-                      "api-reference/rest-apis/v1/documents/update-documents",
-                      "api-reference/rest-apis/v1/documents/delete-documents",
-                      "api-reference/rest-apis/v1/documents/move-documents",
-                      "api-reference/rest-apis/v1/documents/update-document-access",
-                      "api-reference/rest-apis/v1/documents/update-document-disable-state"
-                    ]
-                  },
-                  {
-                    "group": "Users",
-                    "pages": [
-                      "api-reference/rest-apis/v1/users/add-users",
-                      "api-reference/rest-apis/v1/users/get-users",
-                      "api-reference/rest-apis/v1/users/update-users",
-                      "api-reference/rest-apis/v1/users/delete-users"
-                    ]
-                  },
-                  {
-                    "group": "User Groups",
-                    "pages": [
-                      "api-reference/rest-apis/v1/user-groups/add-groups",
-                      "api-reference/rest-apis/v1/user-groups/add-users-to-group",
-                      "api-reference/rest-apis/v1/user-groups/delete-users-from-group"
-                    ]
-                  },
-                  {
-                    "group": "Comments Feature",
-                    "pages": [
-                      {
-                        "group": "Comments Annotations",
-                        "pages": [
-                          "api-reference/rest-apis/v1/comments-feature/comment-annotations/add-comment-annotations",
-                          "api-reference/rest-apis/v1/comments-feature/comment-annotations/get-comment-annotations",
-                          "api-reference/rest-apis/v1/comments-feature/comment-annotations/update-comment-annotations",
-                          "api-reference/rest-apis/v1/comments-feature/comment-annotations/delete-comment-annotations",
-                          "api-reference/rest-apis/v1/comments-feature/comment-annotations/get-comment-annotations-count"
-                        ]
-                      },
-                      {
-                        "group": "Comments",
-                        "pages": [
-                          "api-reference/rest-apis/v1/comments-feature/comments/add-comments",
-                          "api-reference/rest-apis/v1/comments-feature/comments/get-comments",
-                          "api-reference/rest-apis/v1/comments-feature/comments/update-comments",
-                          "api-reference/rest-apis/v1/comments-feature/comments/delete-comments"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Notifications",
-                    "pages": [
-                      "api-reference/rest-apis/v1/notifications/add-notifications",
-                      "api-reference/rest-apis/v1/notifications/get-notifications",
-                      "api-reference/rest-apis/v1/notifications/update-notifications",
-                      "api-reference/rest-apis/v1/notifications/delete-notifications",
-                      "api-reference/rest-apis/v1/notifications/set-config",
-                      "api-reference/rest-apis/v1/notifications/get-config"
-                    ]
-                  },
-                  {
-                    "group": "Access Control",
-                    "pages": [
-                      "api-reference/rest-apis/v1/auth/generate-token"
-                    ]
-                  },
-                  {
-                    "group": "GDPR",
-                    "pages": [
-                      "api-reference/rest-apis/v1/gdpr/get-all-user-data-gdpr",
-                      "api-reference/rest-apis/v1/gdpr/delete-all-user-data-gdpr",
-                      "api-reference/rest-apis/v1/gdpr/get-delete-user-data-status-gdpr"
-                    ]
-                  },
-                  {
-                    "group": "Live State",
-                    "pages": [
-                      "api-reference/rest-apis/v1/livestate/broadcast-event"
-                    ]
-                  },
-                  {
-                    "group": "Workspace",
-                    "pages": [
-                      "api-reference/rest-apis/v1/workspace/add-domain",
-                      "api-reference/rest-apis/v1/workspace/delete-domain"
-                    ]
                   }
                 ]
               }
             ]
+          }
+        ]
+      },
+      {
+        "tab": "Backend SDKs",
+        "groups": [
+          {
+            "group": "Node.js / TypeScript",
+            "pages": [
+              "backend-sdks/node"
+            ]
           },
           {
-            "group": "SDK",
+            "group": "Python",
             "pages": [
-              {
-                "group": "APIs",
-                "pages": [
-                  "api-reference/sdk/api/api-methods",
-                  "api-reference/sdk/api/react-hooks"
-                ]
-              },
-              "api-reference/sdk/models/data-models"
+              "backend-sdks/python"
             ]
           }
         ]
@@ -1058,547 +695,53 @@
         "tab": "Release Notes",
         "groups": [
           {
-            "group": "Release Notes",
+            "group": "Version 5.0.0",
             "pages": [
+              "release-notes/version-5/upgrade-guide",
+              "release-notes/version-5/sdk-changelog",
               {
-                "group": "Version 5.0.0",
+                "group": "CRDT Libraries Changelog",
                 "pages": [
-                  "release-notes/version-5/upgrade-guide",
-                  "release-notes/version-5/sdk-changelog",
-                  {
-                    "group": "CRDT Libraries Changelog",
-                    "pages": [
-                      "release-notes/version-5/crdt-core-changelog"
-                    ]
-                  },
-                  {
-                    "group": "Backend SDKs",
-                    "pages": [
-                      "release-notes/version-5/velt-py-changelog",
-                      "release-notes/version-5/velt-node-changelog"
-                    ]
-                  }
+                  "release-notes/version-5/crdt-core-changelog"
                 ]
               },
               {
-                "group": "Version 4.0.0",
+                "group": "Backend SDKs",
                 "pages": [
-                  "release-notes/version-4/upgrade-guide",
-                  "release-notes/version-4/sdk-changelog",
-                  {
-                    "group": "CRDT Libraries Changelog",
-                    "pages": [
-                      "release-notes/version-4/crdt-core-changelog",
-                      "release-notes/version-4/tiptap-changelog",
-                      "release-notes/version-4/blocknote-changelog",
-                      "release-notes/version-4/codemirror-changelog",
-                      "release-notes/version-4/reactflow-changelog"
-                    ]
-                  }
+                  "release-notes/version-5/velt-py-changelog",
+                  "release-notes/version-5/velt-node-changelog",
+                  "release-notes/version-5/firebase-functions-changelog"
                 ]
-              },
+              }
+            ]
+          },
+          {
+            "group": "Version 4.0.0",
+            "pages": [
               "release-notes/3-0-0",
               {
-                "group": "Version 2.0.0 and prior",
+                "group": "Version 4.x SDK Changelog",
                 "pages": [
-                  "release-notes/archive/aug-22-2024",
-                  "release-notes/archive/aug-21-2024",
-                  "release-notes/archive/aug-16-2024",
-                  "release-notes/archive/aug-14-2024",
-                  "release-notes/archive/aug-13-2024",
-                  "release-notes/archive/aug-12-2024",
-                  "release-notes/archive/aug-8-2024",
-                  "release-notes/archive/aug-6-2024",
-                  "release-notes/archive/july-09-2024",
-                  "release-notes/archive/july-04-2024",
-                  "release-notes/archive/july-03-2024",
-                  "release-notes/archive/july-02-2024",
-                  "release-notes/archive/june-30-2024",
-                  "release-notes/archive/june-29-2024",
-                  "release-notes/archive/june-24-2024",
-                  "release-notes/archive/june-10-2024",
-                  "release-notes/archive/june-6-2024",
-                  "release-notes/archive/may-29-2024",
-                  "release-notes/archive/may-24-2024",
-                  "release-notes/archive/may-23-2024",
-                  "release-notes/archive/may-17-2024",
-                  "release-notes/archive/may-10-2024",
-                  "release-notes/archive/april-24-2024",
-                  "release-notes/archive/april-16-2024",
-                  "release-notes/archive/march-14-2024",
-                  "release-notes/archive/march-5-2024",
-                  "release-notes/archive/feb-27-2024",
-                  "release-notes/archive/feb-20-2024",
-                  "release-notes/archive/feb-13-2024",
-                  "release-notes/archive/jan-14-2024",
-                  "release-notes/archive/dec-28-2023"
+                  "release-notes/version-4/sdk-changelog"
+                ]
+              },
+              {
+                "group": "CRDT Libraries Changelog",
+                "pages": [
+                  "release-notes/version-4/crdt-core-changelog"
+                ]
+              },
+              {
+                "group": "Backend SDKs",
+                "pages": [
+                  "release-notes/version-4/velt-py-changelog",
+                  "release-notes/version-4/velt-node-changelog"
                 ]
               }
             ]
           }
         ]
-      },
-      {
-        "tab": "Examples",
-        "href": "https://velt.dev/examples"
-      },
-      {
-        "tab": "DevTools",
-        "href": "https://velt.dev/devtools"
       }
     ]
-  },
-  "redirects": [
-    {
-      "source": "/async-collaboration/comments-sidebar/setup",
-      "destination": "/async-collaboration/comments-sidebar/v1/setup"
-    },
-    {
-      "source": "/async-collaboration/comments-sidebar/customize-behavior",
-      "destination": "/async-collaboration/comments-sidebar/v1/customize-behavior"
-    },
-    {
-      "source": "/api-reference/rest-apis/v2/approval-engine/overview",
-      "destination": "/ai/approval-engine/overview"
-    },
-    {
-      "source": "/release-notes/version-4/changelog",
-      "destination": "/release-notes/version-4/sdk-changelog"
-    },
-    {
-      "source": "/notifications/email/overview",
-      "destination": "/async-collaboration/comments/notifications#email-notifications"
-    },
-    {
-      "source": "/get-started/setup/install",
-      "destination": "/get-started/quickstart"
-    },
-    {
-      "source": "/get-started/setup",
-      "destination": "/get-started/quickstart"
-    },
-    {
-      "source": "/ui-customization/features/async/notifications/notifications-tool",
-      "destination": "/ui-customization/features/async/notifications/notifications-tool/wireframes"
-    },
-    {
-      "source": "/ui-customization/features/async/notifications/notifications-panel",
-      "destination": "/ui-customization/features/async/notifications/notifications-panel/wireframes"
-    },
-    {
-      "source": "/ui-customization/features/async/notifications/notifications-primitives",
-      "destination": "/ui-customization/features/async/notifications/notifications-panel/primitives"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comment-bubble",
-      "destination": "/ui-customization/features/async/comments/comment-bubble/wireframes"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comment-pin",
-      "destination": "/ui-customization/features/async/comments/comment-pin/wireframes"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comment-sidebar-button",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar-button/wireframes"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/inline-comments-section",
-      "destination": "/ui-customization/features/async/comments/inline-comments-section/wireframes"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/multithread-comment-dialog",
-      "destination": "/ui-customization/features/async/comments/multithread-comments/wireframes"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/text-comment-tool",
-      "destination": "/ui-customization/features/async/comments/text-comment/text-comment-tool/wireframes"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/text-comment-toolbar",
-      "destination": "/ui-customization/features/async/comments/text-comment/text-comment-toolbar/wireframes"
-    },
-    {
-      "source": "/key-concepts/access-control/overview",
-      "destination": "/key-concepts/overview#access-control"
-    },
-    {
-      "source": "/get-started/setup/authenticate",
-      "destination": "/get-started/advanced#jwt-authentication-tokens"
-    },
-    {
-      "source": "/api-reference/api-methods/comments",
-      "destination": "/api-reference/sdk/api/api-methods"
-    },
-    {
-      "source": "/api-reference/hooks/hooks",
-      "destination": "/api-reference/sdk/api/react-hooks"
-    },
-    {
-      "source": "/api-reference/models/Comment",
-      "destination": "/api-reference/sdk/models/data-models"
-    },
-    {
-      "source": "/api-reference/models/CommentAnnotation",
-      "destination": "/api-reference/sdk/models/data-models"
-    },
-    {
-      "source": "/api-reference/models/RecorderData",
-      "destination": "/api-reference/sdk/models/data-models"
-    },
-    {
-      "source": "/api-reference/rest-apis",
-      "destination": "/api-reference/rest-apis/v2/workspace/create"
-    },
-    {
-      "source": "/api-reference/rest-apis/comments-feature/comment-annotations/get-comment-annotations-v2",
-      "destination": "/api-reference/rest-apis/v2/comments-feature/comment-annotations/get-comment-annotations-v2"
-    },
-    {
-      "source": "/api-reference/rest-apis/documents/add-documents",
-      "destination": "/api-reference/rest-apis/v2/documents/add-documents"
-    },
-    {
-      "source": "/api-reference/rest-apis/organizations/add-organizations",
-      "destination": "/api-reference/rest-apis/v2/organizations/add-organizations"
-    },
-    {
-      "source": "/async-collaboration/comment-thread/overview",
-      "destination": "/async-collaboration/comments/overview"
-    },
-    {
-      "source": "/async-collaboration/comments/customize-behavior/@mentions",
-      "destination": "/async-collaboration/comments/customize-behavior#mentions"
-    },
-    {
-      "source": "/async-collaboration/comments/customize-behavior/action-methods",
-      "destination": "/async-collaboration/comments/customize-behavior"
-    },
-    {
-      "source": "/async-collaboration/comments/customize-behavior/autocomplete",
-      "destination": "/async-collaboration/comments/customize-behavior"
-    },
-    {
-      "source": "/async-collaboration/comments/customize-behavior/custom-lists",
-      "destination": "/async-collaboration/comments/customize-behavior#custom-lists"
-    },
-    {
-      "source": "/async-collaboration/comments/customize-behavior/general-controls",
-      "destination": "/async-collaboration/comments/customize-behavior"
-    },
-    {
-      "source": "/async-collaboration/comments/customize-behavior/modes",
-      "destination": "/async-collaboration/comments/customize-behavior"
-    },
-    {
-      "source": "/async-collaboration/comments/customize-behavior/multimedia",
-      "destination": "/async-collaboration/comments/customize-behavior"
-    },
-    {
-      "source": "/async-collaboration/comments/customize-behavior/ui-controls",
-      "destination": "/async-collaboration/comments/customize-behavior"
-    },
-    {
-      "source": "/async-collaboration/comments/customize-behavior/visibility-controls",
-      "destination": "/async-collaboration/comments/customize-behavior"
-    },
-    {
-      "source": "/async-collaboration/notifications/api-add-notification",
-      "destination": "/async-collaboration/notifications/customize-behavior"
-    },
-    {
-      "source": "/key-concepts",
-      "destination": "/key-concepts/overview"
-    },
-    {
-      "source": "/key-concepts/client",
-      "destination": "/key-concepts/overview"
-    },
-    {
-      "source": "/key-concepts/organizations/setup",
-      "destination": "/key-concepts/overview#organizations"
-    },
-    {
-      "source": "/key-concepts/users/organization-user-groups",
-      "destination": "/key-concepts/overview#user-groups"
-    },
-    {
-      "source": "/key-concepts/locations/setup/api-update-location",
-      "destination": "/key-concepts/overview#locations"
-    },
-    {
-      "source": "/ui-customization/customize-css/remove-shadow-dom",
-      "destination": "/ui-customization/styling"
-    },
-    {
-      "source": "/ui-customization/customize-css/themes",
-      "destination": "/ui-customization/styling#themes"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comment-dialog-components",
-      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comment-dialog-primitives/overview",
-      "destination": "/ui-customization/features/async/comments/comment-dialog/primitives"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/autocomplete-chip-tooltip",
-      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/autocomplete-group-option",
-      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/autocomplete-option",
-      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/body/subcomponents/replyavatars",
-      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/body/subcomponents/threadcard",
-      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/body/subcomponents/togglereply",
-      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/header",
-      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes#header"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/navigation-button",
-      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/options-dropdown",
-      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/priority-dropdown",
-      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/reaction-pin",
-      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/reaction-pin-tooltip",
-      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/reaction-tool",
-      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/reactions-panel",
-      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/status-dropdown",
-      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comment-sidebar-components",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comment-sidebar-components-v2",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar-structure-v2"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comment-sidebar-componentscomment-sidebar-components",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar-structure-v2"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comments-sidebar/sidebar-button/overview",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar-button/wireframes"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comments-sidebar/sidebar-button/subcomponents/icon",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar-button/wireframes"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/overview",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/assigned",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/category",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/close-button",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/custom",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/done-button",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/filter-item",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/groupby",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/location",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/people",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/priority",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/reset-button",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/status",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/tagged",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/title",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/versions",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/focused-thread",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar-structure-v2"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/header/overview",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/header/subcomponents/status/overview",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/header/subcomponents/status/subcomponents/content",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/header/subcomponents/status/subcomponents/trigger",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/list/overview",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/list/subcomponents/dialog-container",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/list/subcomponents/group",
-      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/confirm-dialog/overview",
-      "destination": "/ui-customization/features/async/comments/confirm-dialog"
-    },
-    {
-      "source": "/ui-customization/features/async/comments/inline-comments-section/subcomponents/panel/sorting-dropdown",
-      "destination": "/ui-customization/features/async/comments/inline-comments-section/wireframes"
-    },
-    {
-      "source": "/realtime-collaboration/presence/heartbeat",
-      "destination": "/realtime-collaboration/presence/overview#heartbeat-monitoring"
-    },
-    {
-      "source": "/ai-copilot/design/setup",
-      "destination": "/ai/rewriter/setup"
-    },
-    {
-      "source": "/users/client-side/setup",
-      "destination": "/key-concepts/overview#users"
-    },
-    {
-      "source": "/users/server-side/api-reset-contact-list",
-      "destination": "/api-reference/rest-apis/v2/users/delete-users"
-    }
-  ],
-  "logo": {
-    "light": "/velt-logo-big-light.png",
-    "dark": "/velt-logo-big.png",
-    "href": "https://docs.velt.dev"
-  },
-  "api": {
-    "playground": {
-      "display": "interactive"
-    }
-  },
-  "appearance": {
-    "default": "dark"
-  },
-  "background": {
-    "color": {
-      "dark": "#090014"
-    }
-  },
-  "navbar": {
-    "primary": {
-      "type": "button",
-      "label": "Get API Key",
-      "href": "https://console.velt.dev/"
-    }
-  },
-  "search": {
-    "prompt": "Search or ask..."
-  },
-  "contextual": {
-    "options": [
-      "copy",
-      "view",
-      "chatgpt",
-      "claude",
-      "perplexity"
-    ]
-  },
-  "seo": {
-    "metatags": {
-      "og:image": "https://firebasestorage.googleapis.com/v0/b/snippyly.appspot.com/o/external%2Fvelt_docs.png?alt=media&token=9e4502da-66ef-4005-9124-dbc76f04b1fd",
-      "twitter:image": "https://firebasestorage.googleapis.com/v0/b/snippyly.appspot.com/o/external%2Fvelt_docs.png?alt=media&token=9e4502da-66ef-4005-9124-dbc76f04b1fd",
-      "twitter:card": "summary_large_image"
-    },
-    "indexing": "all"
-  },
-  "footer": {
-    "socials": {
-      "twitter": "https://twitter.com/veltjs",
-      "linkedin": "https://www.linkedin.com/company/veltjs"
-    }
-  },
-  "integrations": {
-    "mixpanel": {
-      "projectToken": "6fe5c5cd3adeb341288776482e7bb147"
-    },
-    "intercom": {
-      "appId": "fxx14qnk"
-    }
   }
 }

--- a/docs.json
+++ b/docs.json
@@ -55,60 +55,142 @@
                       "async-collaboration/comments/setup/freestyle",
                       "async-collaboration/comments/setup/page",
                       "async-collaboration/comments/setup/popover",
-                      "async-collaboration/comments/setup/inline",
+                      "async-collaboration/comments/setup/stream",
                       "async-collaboration/comments/setup/text",
-                      "async-collaboration/comments/setup/area",
-                      "async-collaboration/comments/setup/pin"
-                    ]
-                  },
-                  {
-                    "group": "Comments Sidebar",
-                    "pages": [
-                      "async-collaboration/comments-sidebar/overview",
-                      "async-collaboration/comments-sidebar/setup",
                       {
-                        "group": "v2",
+                        "group": "Text Editors Setup (Tiptap, SlateJS, Quill, Lexical, Plate, CodeMirror, Ace, Apryse)",
                         "pages": [
-                          "async-collaboration/comments-sidebar/v2/overview",
-                          "async-collaboration/comments-sidebar/v2/setup"
+                          "async-collaboration/comments/setup/tiptap",
+                          "async-collaboration/comments/setup/slatejs",
+                          "async-collaboration/comments/setup/quill",
+                          "async-collaboration/comments/setup/lexical",
+                          "async-collaboration/comments/setup/plate",
+                          "async-collaboration/comments/setup/codemirror",
+                          "async-collaboration/comments/setup/ace",
+                          "async-collaboration/comments/setup/apryse"
+                        ]
+                      },
+                      "async-collaboration/comments/setup/inline-comments",
+                      "async-collaboration/comments/setup/lottie-player-setup",
+                      {
+                        "group": "Video Player Setup",
+                        "pages": [
+                          "async-collaboration/comments/setup/video-player-setup/video-player-setup",
+                          "async-collaboration/comments/setup/video-player-setup/custom-video-player-setup"
+                        ]
+                      },
+                      {
+                        "group": "Chart Comments Setup",
+                        "pages": [
+                          "async-collaboration/comments/setup/chart-comments-setup/highcharts",
+                          "async-collaboration/comments/setup/chart-comments-setup/nivo-charts",
+                          "async-collaboration/comments/setup/chart-comments-setup/chartjs",
+                          "async-collaboration/comments/setup/chart-comments-setup/custom-charts"
+                        ]
+                      },
+                      {
+                        "group": "Standalone Components (DIY)",
+                        "pages": [
+                          {
+                            "group": "Comment Composer",
+                            "pages": [
+                              "async-collaboration/comments/standalone-components/comment-composer/overview",
+                              "async-collaboration/comments/standalone-components/comment-composer/setup",
+                              "async-collaboration/comments/standalone-components/comment-composer/customize-behavior"
+                            ]
+                          },
+                          {
+                            "group": "Comment Thread",
+                            "pages": [
+                              "async-collaboration/comments/standalone-components/comment-thread/overview",
+                              "async-collaboration/comments/standalone-components/comment-thread/setup",
+                              "async-collaboration/comments/standalone-components/comment-thread/customize-behavior"
+                            ]
+                          },
+                          {
+                            "group": "Comment Pin",
+                            "pages": [
+                              "async-collaboration/comments/standalone-components/comment-pin/overview",
+                              "async-collaboration/comments/standalone-components/comment-pin/setup",
+                              "async-collaboration/comments/standalone-components/comment-pin/customize-behavior"
+                            ]
+                          }
                         ]
                       }
                     ]
                   },
-                  "async-collaboration/comments/navigate-on-click",
-                  "async-collaboration/comments/url-navigation"
+                  "async-collaboration/comments/customize-behavior",
+                  {
+                    "group": "Comments Sidebar",
+                    "pages": [
+                      "async-collaboration/comments-sidebar/overview",
+                      {
+                        "group": "V1",
+                        "pages": [
+                          "async-collaboration/comments-sidebar/v1/setup",
+                          "async-collaboration/comments-sidebar/v1/customize-behavior"
+                        ]
+                      },
+                      {
+                        "group": "V2",
+                        "pages": [
+                          "async-collaboration/comments-sidebar/v2/setup",
+                          "async-collaboration/comments-sidebar/v2/customize-behavior"
+                        ]
+                      }
+                    ]
+                  },
+                  "async-collaboration/comments/notifications"
                 ]
               },
               {
-                "group": "Notifications",
+                "group": "In-app Notifications",
                 "pages": [
                   "async-collaboration/notifications/overview",
                   "async-collaboration/notifications/setup",
-                  "async-collaboration/notifications/inbox",
-                  "async-collaboration/notifications/digest"
+                  "async-collaboration/notifications/customize-behavior"
                 ]
               },
               {
-                "group": "Activity Log",
+                "group": "Activity Logs",
                 "pages": [
-                  "async-collaboration/activity-log/overview",
-                  "async-collaboration/activity-log/setup"
+                  "async-collaboration/activity/overview",
+                  "async-collaboration/activity/setup",
+                  "async-collaboration/activity/customize-behavior"
+                ]
+              },
+              {
+                "group": "Inline Reactions",
+                "pages": [
+                  "async-collaboration/reactions/overview",
+                  "async-collaboration/reactions/setup"
                 ]
               },
               {
                 "group": "Recorder",
                 "pages": [
                   "async-collaboration/recorder/overview",
-                  "async-collaboration/recorder/setup"
+                  "async-collaboration/recorder/setup",
+                  "async-collaboration/recorder/customize-behavior"
                 ]
               },
               {
-                "group": "Arrow",
+                "group": "View Analytics",
                 "pages": [
-                  "async-collaboration/arrow/overview",
-                  "async-collaboration/arrow/setup"
+                  "async-collaboration/view-analytics/overview",
+                  "async-collaboration/view-analytics/setup",
+                  "async-collaboration/view-analytics/customize-behavior"
                 ]
-              }
+              },
+              {
+                "group": "Arrows",
+                "pages": [
+                  "async-collaboration/arrows/overview",
+                  "async-collaboration/arrows/setup",
+                  "async-collaboration/arrows/customize-behavior"
+                ]
+              },
+              "async-collaboration/suggestions/overview"
             ]
           },
           {
@@ -118,166 +200,173 @@
                 "group": "Presence",
                 "pages": [
                   "realtime-collaboration/presence/overview",
-                  "realtime-collaboration/presence/setup"
+                  "realtime-collaboration/presence/setup",
+                  "realtime-collaboration/presence/customize-behavior"
                 ]
               },
               {
                 "group": "Cursors",
                 "pages": [
                   "realtime-collaboration/cursors/overview",
-                  "realtime-collaboration/cursors/setup"
+                  "realtime-collaboration/cursors/setup",
+                  "realtime-collaboration/cursors/customize-behavior"
+                ]
+              },
+              {
+                "group": "Follow Me Mode",
+                "pages": [
+                  "realtime-collaboration/flock-mode/overview",
+                  "realtime-collaboration/flock-mode/setup",
+                  "realtime-collaboration/flock-mode/customize-behavior"
                 ]
               },
               {
                 "group": "Huddle",
                 "pages": [
                   "realtime-collaboration/huddle/overview",
-                  "realtime-collaboration/huddle/setup"
+                  "realtime-collaboration/huddle/setup",
+                  "realtime-collaboration/huddle/customize-behavior"
+                ]
+              },
+              {
+                "group": "Live Selection",
+                "pages": [
+                  "realtime-collaboration/live-selection/overview",
+                  "realtime-collaboration/live-selection/setup",
+                  "realtime-collaboration/live-selection/customize-behavior"
+                ]
+              },
+              {
+                "group": "Live State Sync",
+                "pages": [
+                  "realtime-collaboration/live-state-sync/overview",
+                  "realtime-collaboration/live-state-sync/setup",
+                  "realtime-collaboration/live-state-sync/redux-middleware"
                 ]
               },
               {
                 "group": "Single Editor Mode",
                 "pages": [
                   "realtime-collaboration/single-editor-mode/overview",
-                  "realtime-collaboration/single-editor-mode/setup"
+                  "realtime-collaboration/single-editor-mode/setup",
+                  "realtime-collaboration/single-editor-mode/customize-behavior"
+                ]
+              },
+              {
+                "group": "Multiplayer Editing (Yjs)",
+                "pages": [
+                  "realtime-collaboration/crdt/overview",
+                  {
+                    "group": "Core",
+                    "pages": [
+                      "realtime-collaboration/crdt/setup/core",
+                      "realtime-collaboration/crdt/setup/core-stores/array",
+                      "realtime-collaboration/crdt/setup/core-stores/map",
+                      "realtime-collaboration/crdt/setup/core-stores/text",
+                      "realtime-collaboration/crdt/setup/core-stores/xml"
+                    ]
+                  },
+                  "realtime-collaboration/crdt/setup/tiptap",
+                  "realtime-collaboration/crdt/setup/blocknote",
+                  "realtime-collaboration/crdt/setup/codemirror",
+                  "realtime-collaboration/crdt/setup/reactflow"
+                ]
+              },
+              {
+                "group": "Video Player Sync",
+                "pages": [
+                  "realtime-collaboration/video-player-sync/overview",
+                  "realtime-collaboration/video-player-sync/setup"
                 ]
               }
             ]
           },
           {
-            "group": "Live Co-Editing (CRDT)",
+            "group": "AI",
             "pages": [
               {
-                "group": "Overview",
+                "group": "Rewriter",
                 "pages": [
-                  "live-co-editing/overview",
-                  "live-co-editing/crdt-overview"
+                  "ai/rewriter/overview",
+                  "ai/rewriter/setup",
+                  "ai/rewriter/customize-behavior"
                 ]
               },
               {
-                "group": "Velt CRDT Libraries",
-                "pages": [
-                  {
-                    "group": "BlockNote",
-                    "pages": [
-                      "live-co-editing/blocknote/overview",
-                      "live-co-editing/blocknote/setup"
-                    ]
-                  },
-                  {
-                    "group": "CodeMirror",
-                    "pages": [
-                      "live-co-editing/codemirror/overview",
-                      "live-co-editing/codemirror/setup"
-                    ]
-                  },
-                  {
-                    "group": "Yjs Proxy",
-                    "pages": [
-                      "live-co-editing/yjs-proxy/overview",
-                      "live-co-editing/yjs-proxy/setup"
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "group": "AI Features",
-            "pages": [
-              {
-                "group": "AI Agents",
-                "pages": [
-                  "ai/agents/overview",
-                  "ai/agents/setup",
-                  "ai/agents/custom-agents",
-                  "ai/agents/groups"
-                ]
-              },
-              {
-                "group": "Memory",
-                "pages": [
-                  "ai/memory/overview",
-                  "ai/memory/setup"
-                ]
-              },
-              {
-                "group": "Approval Engine",
+                "group": "Approval Engine (Beta)",
                 "pages": [
                   "ai/approval-engine/overview",
-                  "ai/approval-engine/setup"
+                  "ai/approval-engine/setup",
+                  "ai/approval-engine/customize-behavior"
                 ]
-              }
-            ]
-          },
-          {
-            "group": "Access Control",
-            "pages": [
-              "permission-management/overview"
-            ]
-          },
-          {
-            "group": "In-App User Feedback",
-            "pages": [
-              "in-app-user-feedback/overview",
-              "in-app-user-feedback/setup"
-            ]
-          },
-          {
-            "group": "Security",
-            "pages": [
-              "security/overview"
+              },
+              {
+                "group": "Activity Logs",
+                "pages": [
+                  "async-collaboration/activity/overview",
+                  "async-collaboration/activity/setup",
+                  "async-collaboration/activity/customize-behavior"
+                ]
+              },
+              "ai/agent-comments",
+              "ai/chat-sdk-adapter"
             ]
           },
           {
             "group": "Self-Host Data",
             "pages": [
-              {
-                "group": "Overview",
-                "pages": [
-                  "self-host-data/overview",
-                  "self-host-data/setup"
-                ]
-              },
-              {
-                "group": "YJS",
-                "pages": [
-                  "self-host-data/yjs/overview",
-                  "self-host-data/yjs/setup"
-                ]
-              },
-              {
-                "group": "Proxy Server",
-                "pages": [
-                  "self-host-data/proxy-server/overview",
-                  "self-host-data/proxy-server/setup"
-                ]
-              }
+              "self-host-data/overview",
+              "self-host-data/users",
+              "self-host-data/comments",
+              "self-host-data/reactions",
+              "self-host-data/attachments",
+              "self-host-data/recordings",
+              "self-host-data/activity",
+              "self-host-data/notifications",
+              "self-host-data/field-inventory"
             ]
           },
           {
-            "group": "Integrations",
+            "group": "Backend SDKs",
             "pages": [
-              "integrations/zapier"
+              "backend-sdks/python",
+              "backend-sdks/node"
+            ]
+          },
+          {
+            "group": "Model Context Protocol",
+            "pages": [
+              "mcp/mcp"
             ]
           },
           {
             "group": "Webhooks",
             "pages": [
-              "webhooks/overview",
-              "webhooks/setup"
+              "webhooks/basic",
+              "webhooks/advanced"
             ]
           },
           {
-            "group": "MCP",
+            "group": "Security",
             "pages": [
-              "mcp/overview"
+              "security/content-security-policy",
+              "security/auth-tokens",
+              "security/proxy-server",
+              "security/supported-regions"
             ]
           },
           {
-            "group": "Migration",
+            "group": "Miscellaneous",
             "pages": [
-              "migration/migration-guide"
+              "migration/environments",
+              "migration/migrate-from-cord-to-velt",
+              "migration/migrate-from-liveblocks-to-velt",
+              {
+                "group": "Common Integration Questions",
+                "pages": [
+                  "integrations/ag-grid"
+                ]
+              }
             ]
           }
         ]
@@ -286,9 +375,16 @@
         "tab": "UI Customization",
         "groups": [
           {
-            "group": "Overview",
+            "group": "Concepts",
             "pages": [
-              "ui-customization/overview"
+              "ui-customization/overview",
+              "ui-customization/setup",
+              "ui-customization/layout",
+              "ui-customization/styling",
+              "ui-customization/template-variables",
+              "ui-customization/conditional-templates",
+              "ui-customization/custom-action-component",
+              "ui-customization/localisation"
             ]
           },
           {
@@ -298,151 +394,132 @@
                 "group": "Comments",
                 "pages": [
                   {
-                    "group": "Comment Tool",
+                    "group": "Comment Dialog",
                     "pages": [
-                      "ui-customization/features/async/comments/comment-tool/overview",
-                      "ui-customization/features/async/comments/comment-tool/wireframe-variables",
-                      {
-                        "group": "Primitives",
-                        "pages": [
-                          "ui-customization/features/async/comments/comment-tool/primitives"
-                        ]
-                      }
+                      "ui-customization/features/async/comments/comment-dialog/wireframes",
+                      "ui-customization/features/async/comments/comment-dialog/wireframe-variables",
+                      "ui-customization/features/async/comments/comment-dialog/primitives"
                     ]
                   },
                   {
-                    "group": "Comment Pin",
+                    "group": "Comment Sidebar",
                     "pages": [
-                      "ui-customization/features/async/comments/comment-pin/overview",
-                      "ui-customization/features/async/comments/comment-pin/wireframe-variables",
+                      "ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components",
+                      "ui-customization/features/async/comments/comment-sidebar/comment-sidebar-v2-wireframes",
+                      "ui-customization/features/async/comments/comment-sidebar/comment-sidebar-wireframe-variables",
+                      "ui-customization/features/async/comments/comment-sidebar/comment-sidebar-v2-primitives"
+                    ]
+                  },
+                  {
+                    "group": "Comment Sidebar Button",
+                    "pages": [
+                      "ui-customization/features/async/comments/comment-sidebar-button/wireframes",
+                      "ui-customization/features/async/comments/comment-sidebar-button/wireframe-variables",
+                      "ui-customization/features/async/comments/comment-sidebar-button/primitives"
+                    ]
+                  },
+                  {
+                    "group": "Standalone Components (DIY)",
+                    "pages": [
+                      "ui-customization/features/async/comments/standalone-components/comment-composer",
+                      "ui-customization/features/async/comments/standalone-components/comment-thread",
                       {
-                        "group": "Primitives",
+                        "group": "Comment Pin",
                         "pages": [
+                          "ui-customization/features/async/comments/comment-pin/wireframes",
                           "ui-customization/features/async/comments/comment-pin/primitives"
                         ]
                       }
                     ]
                   },
                   {
-                    "group": "Comment Dialog",
+                    "group": "Inline Comments Section",
                     "pages": [
-                      "ui-customization/features/async/comments/comment-dialog/overview",
-                      "ui-customization/features/async/comments/comment-dialog/wireframe-variables",
-                      {
-                        "group": "Primitives",
-                        "pages": [
-                          "ui-customization/features/async/comments/comment-dialog/primitives"
-                        ]
-                      }
+                      "ui-customization/features/async/comments/inline-comments-section/wireframes",
+                      "ui-customization/features/async/comments/inline-comments-section/wireframe-variables",
+                      "ui-customization/features/async/comments/inline-comments-section/primitives"
+                    ]
+                  },
+                  {
+                    "group": "Comment Pin",
+                    "pages": [
+                      "ui-customization/features/async/comments/comment-pin/wireframes",
+                      "ui-customization/features/async/comments/comment-pin/primitives"
+                    ]
+                  },
+                  {
+                    "group": "Comment Tool",
+                    "pages": [
+                      "ui-customization/features/async/comments/comment-tool",
+                      "ui-customization/features/async/comments/comment-tool-wireframe-variables"
+                    ]
+                  },
+                  {
+                    "group": "Autocomplete",
+                    "pages": [
+                      "ui-customization/features/async/comments/autocomplete-wireframe-variables"
                     ]
                   },
                   {
                     "group": "Comment Bubble",
                     "pages": [
-                      "ui-customization/features/async/comments/comment-bubble/overview",
+                      "ui-customization/features/async/comments/comment-bubble/wireframes",
                       "ui-customization/features/async/comments/comment-bubble/wireframe-variables",
+                      "ui-customization/features/async/comments/comment-bubble/primitives"
+                    ]
+                  },
+                  "ui-customization/features/async/comments/comment-player-timeline",
+                  "ui-customization/features/async/comments/confirm-dialog",
+                  {
+                    "group": "Multithread Comments",
+                    "pages": [
+                      "ui-customization/features/async/comments/multithread-comments/wireframes",
+                      "ui-customization/features/async/comments/multithread-comments/wireframe-variables",
+                      "ui-customization/features/async/comments/multithread-comments/primitives"
+                    ]
+                  },
+                  "ui-customization/features/async/comments/persistent-comment-mode-banner",
+                  {
+                    "group": "Text Comment",
+                    "pages": [
+                      "ui-customization/features/async/comments/text-comment-wireframe-variables",
+                      "ui-customization/features/async/comments/text-comment-primitives",
                       {
-                        "group": "Primitives",
+                        "group": "Text Comment Tool",
                         "pages": [
-                          "ui-customization/features/async/comments/comment-bubble/primitives"
+                          "ui-customization/features/async/comments/text-comment/text-comment-tool/wireframes",
+                          "ui-customization/features/async/comments/text-comment/text-comment-tool/primitives"
+                        ]
+                      },
+                      {
+                        "group": "Text Comment Toolbar",
+                        "pages": [
+                          "ui-customization/features/async/comments/text-comment/text-comment-toolbar/wireframes",
+                          "ui-customization/features/async/comments/text-comment/text-comment-toolbar/primitives"
                         ]
                       }
                     ]
                   },
-                  {
-                    "group": "Comment Sidebar",
-                    "pages": [
-                      "ui-customization/features/async/comments/comment-sidebar/overview",
-                      "ui-customization/features/async/comments/comment-sidebar/wireframe-variables",
-                      {
-                        "group": "Primitives",
-                        "pages": [
-                          "ui-customization/features/async/comments/comment-sidebar/primitives"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Comment Minimap",
-                    "pages": [
-                      "ui-customization/features/async/comments/comment-minimap/overview",
-                      "ui-customization/features/async/comments/comment-minimap/wireframe-variables",
-                      {
-                        "group": "Primitives",
-                        "pages": [
-                          "ui-customization/features/async/comments/comment-minimap/primitives"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Comment Count",
-                    "pages": [
-                      "ui-customization/features/async/comments/comment-count/overview",
-                      "ui-customization/features/async/comments/comment-count/wireframe-variables",
-                      {
-                        "group": "Primitives",
-                        "pages": [
-                          "ui-customization/features/async/comments/comment-count/primitives"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Inline Comment",
-                    "pages": [
-                      "ui-customization/features/async/comments/inline-comment/overview",
-                      "ui-customization/features/async/comments/inline-comment/wireframe-variables",
-                      {
-                        "group": "Primitives",
-                        "pages": [
-                          "ui-customization/features/async/comments/inline-comment/primitives"
-                        ]
-                      }
-                    ]
-                  }
+                  "ui-customization/features/async/comments/comment-video-player"
                 ]
               },
               {
-                "group": "Notifications",
+                "group": "In-app Notifications",
                 "pages": [
                   {
-                    "group": "Notification Tool",
+                    "group": "Notifications Tool",
                     "pages": [
-                      "ui-customization/features/async/notifications/notification-tool/overview",
-                      "ui-customization/features/async/notifications/notification-tool/wireframe-variables",
-                      {
-                        "group": "Primitives",
-                        "pages": [
-                          "ui-customization/features/async/notifications/notification-tool/primitives"
-                        ]
-                      }
+                      "ui-customization/features/async/notifications/notifications-tool/wireframes",
+                      "ui-customization/features/async/notifications/notifications-tool/wireframe-variables",
+                      "ui-customization/features/async/notifications/notifications-tool/primitives"
                     ]
                   },
                   {
-                    "group": "Notification Panel",
+                    "group": "Notifications Panel",
                     "pages": [
-                      "ui-customization/features/async/notifications/notification-panel/overview",
-                      "ui-customization/features/async/notifications/notification-panel/wireframe-variables",
-                      {
-                        "group": "Primitives",
-                        "pages": [
-                          "ui-customization/features/async/notifications/notification-panel/primitives"
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Activity Log",
-                "pages": [
-                  "ui-customization/features/async/activity-logs/overview",
-                  "ui-customization/features/async/activity-logs/wireframe-variables",
-                  {
-                    "group": "Primitives",
-                    "pages": [
-                      "ui-customization/features/async/activity-logs/activity-logs-primitives"
+                      "ui-customization/features/async/notifications/notifications-panel/wireframes",
+                      "ui-customization/features/async/notifications/notifications-panel/wireframe-variables",
+                      "ui-customization/features/async/notifications/notifications-panel/primitives"
                     ]
                   }
                 ]
@@ -450,32 +527,66 @@
               {
                 "group": "Recorder",
                 "pages": [
-                  {
-                    "group": "Recorder Notes",
-                    "pages": [
-                      "ui-customization/features/async/recorder/recorder-notes/overview",
-                      "ui-customization/features/async/recorder/recorder-notes/wireframe-variables",
-                      {
-                        "group": "Primitives",
-                        "pages": [
-                          "ui-customization/features/async/recorder/recorder-notes/primitives"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Recorder Control Panel",
-                    "pages": [
-                      "ui-customization/features/async/recorder/recorder-control-panel/overview",
-                      "ui-customization/features/async/recorder/recorder-control-panel/wireframe-variables",
-                      {
-                        "group": "Primitives",
-                        "pages": [
-                          "ui-customization/features/async/recorder/recorder-control-panel/primitives"
-                        ]
-                      }
-                    ]
-                  }
+                  "ui-customization/features/async/recorder/wireframe-variables",
+                  "ui-customization/features/async/recorder/control-panel",
+                  "ui-customization/features/async/recorder/media-source-settings",
+                  "ui-customization/features/async/recorder/recorder-player-expanded",
+                  "ui-customization/features/async/recorder/recorder-player",
+                  "ui-customization/features/async/recorder/recorder-tool",
+                  "ui-customization/features/async/recorder/recording-preview-steps-dialog",
+                  "ui-customization/features/async/recorder/subtitles",
+                  "ui-customization/features/async/recorder/transcription",
+                  "ui-customization/features/async/recorder/transcription-wireframe-variables",
+                  "ui-customization/features/async/recorder/video-editor"
+                ]
+              },
+              {
+                "group": "Reactions",
+                "pages": [
+                  "ui-customization/features/async/inline-reactions",
+                  "ui-customization/features/async/reactions-wireframe-variables"
+                ]
+              },
+              {
+                "group": "Rewriter",
+                "pages": [
+                  "ui-customization/features/async/rewriter/wireframe-variables"
+                ]
+              },
+              {
+                "group": "Arrows",
+                "pages": [
+                  "ui-customization/features/async/arrows/wireframe-variables",
+                  "ui-customization/features/async/arrows/parts",
+                  "ui-customization/features/async/arrows/slots",
+                  "ui-customization/features/async/arrows/variables",
+                  "ui-customization/features/async/arrows/custom-button"
+                ]
+              },
+              {
+                "group": "Area",
+                "pages": [
+                  "ui-customization/features/async/area/wireframe-variables"
+                ]
+              },
+              {
+                "group": "Tag",
+                "pages": [
+                  "ui-customization/features/async/tag/wireframe-variables"
+                ]
+              },
+              {
+                "group": "View Analytics",
+                "pages": [
+                  "ui-customization/features/async/view-analytics/wireframe-variables"
+                ]
+              },
+              {
+                "group": "Activity Logs",
+                "pages": [
+                  "ui-customization/features/async/activity-logs/activity-logs-wireframes",
+                  "ui-customization/features/async/activity-logs/activity-logs-wireframe-variables",
+                  "ui-customization/features/async/activity-logs/activity-logs-primitives"
                 ]
               }
             ]
@@ -486,53 +597,32 @@
               {
                 "group": "Presence",
                 "pages": [
-                  "ui-customization/features/realtime/presence/overview",
-                  "ui-customization/features/realtime/presence/wireframe-variables",
-                  {
-                    "group": "Primitives",
-                    "pages": [
-                      "ui-customization/features/realtime/presence/primitives"
-                    ]
-                  }
+                  "ui-customization/features/realtime/presence",
+                  "ui-customization/features/realtime/presence-wireframe-variables"
                 ]
               },
               {
                 "group": "Cursors",
                 "pages": [
-                  "ui-customization/features/realtime/cursors/overview",
-                  "ui-customization/features/realtime/cursors/wireframe-variables",
-                  {
-                    "group": "Primitives",
-                    "pages": [
-                      "ui-customization/features/realtime/cursors/primitives"
-                    ]
-                  }
+                  "ui-customization/features/realtime/cursors",
+                  "ui-customization/features/realtime/cursors-wireframe-variables"
                 ]
               },
+              "ui-customization/features/realtime/single-editor-mode",
               {
-                "group": "Single Editor Mode",
+                "group": "Live Selection",
                 "pages": [
-                  "ui-customization/features/realtime/single-editor-mode/overview",
-                  "ui-customization/features/realtime/single-editor-mode/wireframe-variables",
-                  {
-                    "group": "Primitives",
-                    "pages": [
-                      "ui-customization/features/realtime/single-editor-mode/primitives"
-                    ]
-                  }
+                  "ui-customization/features/realtime/live-selection",
+                  "ui-customization/features/realtime/live-selection-wireframe-variables"
                 ]
               },
               {
                 "group": "Huddle",
                 "pages": [
-                  "ui-customization/features/realtime/huddle/overview",
                   "ui-customization/features/realtime/huddle/wireframe-variables",
-                  {
-                    "group": "Primitives",
-                    "pages": [
-                      "ui-customization/features/realtime/huddle/primitives"
-                    ]
-                  }
+                  "ui-customization/features/realtime/huddle/parts",
+                  "ui-customization/features/realtime/huddle/slots",
+                  "ui-customization/features/realtime/huddle/variables"
                 ]
               }
             ]
@@ -543,123 +633,104 @@
         "tab": "API Reference",
         "groups": [
           {
-            "group": "SDK",
-            "pages": [
-              {
-                "group": "API Methods",
-                "pages": [
-                  "api-reference/sdk/api/api-methods"
-                ]
-              },
-              {
-                "group": "Data Models",
-                "pages": [
-                  "api-reference/sdk/models/data-models"
-                ]
-              },
-              {
-                "group": "Events",
-                "pages": [
-                  "api-reference/sdk/events/events"
-                ]
-              }
-            ]
-          },
-          {
             "group": "REST APIs",
             "pages": [
-              "api-reference/rest-apis/overview",
               {
-                "group": "V2 APIs",
+                "group": "v2",
                 "pages": [
                   {
-                    "group": "Comments Feature",
+                    "group": "Organizations",
                     "pages": [
-                      {
-                        "group": "Comment Annotations",
-                        "pages": [
-                          "api-reference/rest-apis/v2/comments-feature/comment-annotations/add-comment-annotations",
-                          "api-reference/rest-apis/v2/comments-feature/comment-annotations/update-comment-annotations",
-                          "api-reference/rest-apis/v2/comments-feature/comment-annotations/delete-comment-annotations",
-                          "api-reference/rest-apis/v2/comments-feature/comment-annotations/get-comment-annotations-v2"
-                        ]
-                      },
-                      {
-                        "group": "Comments",
-                        "pages": [
-                          "api-reference/rest-apis/v2/comments-feature/comments/add-comments",
-                          "api-reference/rest-apis/v2/comments-feature/comments/update-comments",
-                          "api-reference/rest-apis/v2/comments-feature/comments/delete-comments",
-                          "api-reference/rest-apis/v2/comments-feature/comments/get-comments"
-                        ]
-                      },
-                      {
-                        "group": "Reactions",
-                        "pages": [
-                          "api-reference/rest-apis/v2/comments-feature/reactions/add-reactions",
-                          "api-reference/rest-apis/v2/comments-feature/reactions/update-reactions",
-                          "api-reference/rest-apis/v2/comments-feature/reactions/delete-reactions",
-                          "api-reference/rest-apis/v2/comments-feature/reactions/get-reactions"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Users",
-                    "pages": [
-                      "api-reference/rest-apis/v2/users/add-users",
-                      "api-reference/rest-apis/v2/users/update-users",
-                      "api-reference/rest-apis/v2/users/delete-users",
-                      "api-reference/rest-apis/v2/users/get-users"
-                    ]
-                  },
-                  {
-                    "group": "Documents",
-                    "pages": [
-                      "api-reference/rest-apis/v2/documents/get-documents",
-                      "api-reference/rest-apis/v2/documents/get-documents-count",
-                      "api-reference/rest-apis/v2/documents/delete-documents"
+                      "api-reference/rest-apis/v2/organizations/add-organizations",
+                      "api-reference/rest-apis/v2/organizations/get-organizations-v2",
+                      "api-reference/rest-apis/v2/organizations/update-organizations",
+                      "api-reference/rest-apis/v2/organizations/delete-organizations",
+                      "api-reference/rest-apis/v2/organizations/update-organization-disable-state"
                     ]
                   },
                   {
                     "group": "Folders",
                     "pages": [
                       "api-reference/rest-apis/v2/folders/add-folder",
+                      "api-reference/rest-apis/v2/folders/get-folders",
                       "api-reference/rest-apis/v2/folders/update-folder",
                       "api-reference/rest-apis/v2/folders/delete-folder",
-                      "api-reference/rest-apis/v2/folders/get-folder"
+                      "api-reference/rest-apis/v2/folders/update-folder-access"
+                    ]
+                  },
+                  {
+                    "group": "Documents",
+                    "pages": [
+                      "api-reference/rest-apis/v2/documents/add-documents",
+                      "api-reference/rest-apis/v2/documents/get-documents-v2",
+                      "api-reference/rest-apis/v2/documents/update-documents",
+                      "api-reference/rest-apis/v2/documents/delete-documents",
+                      "api-reference/rest-apis/v2/documents/move-documents",
+                      "api-reference/rest-apis/v2/documents/migrate-documents",
+                      "api-reference/rest-apis/v2/documents/migrate-documents-status",
+                      "api-reference/rest-apis/v2/documents/update-document-access",
+                      "api-reference/rest-apis/v2/documents/update-document-disable-state"
+                    ]
+                  },
+                  {
+                    "group": "Users",
+                    "pages": [
+                      "api-reference/rest-apis/v2/users/add-users",
+                      "api-reference/rest-apis/v2/users/get-users-v2",
+                      "api-reference/rest-apis/v2/users/update-users",
+                      "api-reference/rest-apis/v2/users/delete-users"
+                    ]
+                  },
+                  {
+                    "group": "User Groups",
+                    "pages": [
+                      "api-reference/rest-apis/v2/user-groups/add-groups",
+                      "api-reference/rest-apis/v2/user-groups/add-users-to-group",
+                      "api-reference/rest-apis/v2/user-groups/delete-users-from-group"
+                    ]
+                  },
+                  {
+                    "group": "Comments Feature",
+                    "pages": [
+                      {
+                        "group": "Comments Annotations",
+                        "pages": [
+                          "api-reference/rest-apis/v2/comments-feature/comment-annotations/add-comment-annotations",
+                          "api-reference/rest-apis/v2/comments-feature/comment-annotations/get-comment-annotations-v2",
+                          "api-reference/rest-apis/v2/comments-feature/comment-annotations/update-comment-annotations",
+                          "api-reference/rest-apis/v2/comments-feature/comment-annotations/delete-comment-annotations",
+                          "api-reference/rest-apis/v2/comments-feature/comment-annotations/get-comment-annotations-count"
+                        ]
+                      },
+                      {
+                        "group": "Comments",
+                        "pages": [
+                          "api-reference/rest-apis/v2/comments-feature/comments/add-comments",
+                          "api-reference/rest-apis/v2/comments-feature/comments/get-comments",
+                          "api-reference/rest-apis/v2/comments-feature/comments/update-comments",
+                          "api-reference/rest-apis/v2/comments-feature/comments/delete-comments"
+                        ]
+                      }
                     ]
                   },
                   {
                     "group": "Notifications",
                     "pages": [
                       "api-reference/rest-apis/v2/notifications/add-notifications",
+                      "api-reference/rest-apis/v2/notifications/get-notifications-v2",
                       "api-reference/rest-apis/v2/notifications/update-notifications",
                       "api-reference/rest-apis/v2/notifications/delete-notifications",
-                      "api-reference/rest-apis/v2/notifications/get-notifications"
+                      "api-reference/rest-apis/v2/notifications/set-config",
+                      "api-reference/rest-apis/v2/notifications/get-config"
                     ]
                   },
                   {
-                    "group": "Activity",
+                    "group": "Activity Logs",
                     "pages": [
-                      "api-reference/rest-apis/v2/activity/add-activities",
-                      "api-reference/rest-apis/v2/activity/update-activities",
-                      "api-reference/rest-apis/v2/activity/delete-activities",
-                      "api-reference/rest-apis/v2/activity/get-activities"
-                    ]
-                  },
-                  {
-                    "group": "Presence",
-                    "pages": [
-                      "api-reference/rest-apis/v2/presence/get-presence"
-                    ]
-                  },
-                  {
-                    "group": "Workspace",
-                    "pages": [
-                      "api-reference/rest-apis/v2/workspace/get-workspace",
-                      "api-reference/rest-apis/v2/workspace/update-workspace",
-                      "api-reference/rest-apis/v2/workspace/add-workspace"
+                      "api-reference/rest-apis/v2/activities/add-activities",
+                      "api-reference/rest-apis/v2/activities/get-activities",
+                      "api-reference/rest-apis/v2/activities/update-activities",
+                      "api-reference/rest-apis/v2/activities/delete-activities"
                     ]
                   },
                   {
@@ -667,26 +738,318 @@
                     "pages": [
                       "api-reference/rest-apis/v2/recordings/get-recordings"
                     ]
+                  },
+                  {
+                    "group": "GDPR",
+                    "pages": [
+                      "api-reference/rest-apis/v2/gdpr/get-all-user-data-gdpr",
+                      "api-reference/rest-apis/v2/gdpr/delete-all-user-data-gdpr",
+                      "api-reference/rest-apis/v2/gdpr/get-delete-user-data-status-gdpr"
+                    ]
+                  },
+                  {
+                    "group": "Access Control",
+                    "pages": [
+                      "api-reference/rest-apis/v2/auth/generate-token",
+                      "api-reference/rest-apis/v2/auth/add-permissions",
+                      "api-reference/rest-apis/v2/auth/get-permissions",
+                      "api-reference/rest-apis/v2/auth/remove-permissions"
+                    ]
+                  },
+                  {
+                    "group": "CRDT",
+                    "pages": [
+                      "api-reference/rest-apis/v2/crdt/get-crdt-data",
+                      "api-reference/rest-apis/v2/crdt/add-crdt-data",
+                      "api-reference/rest-apis/v2/crdt/update-crdt-data"
+                    ]
+                  },
+                  {
+                    "group": "Live State",
+                    "pages": [
+                      "api-reference/rest-apis/v2/livestate/broadcast-event"
+                    ]
+                  },
+                  {
+                    "group": "Presence",
+                    "pages": [
+                      "api-reference/rest-apis/v2/presence/add-presence",
+                      "api-reference/rest-apis/v2/presence/update-presence",
+                      "api-reference/rest-apis/v2/presence/delete-presence"
+                    ]
+                  },
+                  {
+                    "group": "Rewriter",
+                    "pages": [
+                      "api-reference/rest-apis/v2/rewriter/ask-ai"
+                    ]
+                  },
+                  {
+                    "group": "Approval Engine",
+                    "pages": [
+                      {
+                        "group": "Definitions",
+                        "pages": [
+                          "api-reference/rest-apis/v2/approval-engine/definitions/create-definition",
+                          "api-reference/rest-apis/v2/approval-engine/definitions/update-definition",
+                          "api-reference/rest-apis/v2/approval-engine/definitions/delete-definition",
+                          "api-reference/rest-apis/v2/approval-engine/definitions/get-definition",
+                          "api-reference/rest-apis/v2/approval-engine/definitions/list-definitions"
+                        ]
+                      },
+                      {
+                        "group": "Executions",
+                        "pages": [
+                          "api-reference/rest-apis/v2/approval-engine/executions/dispatch-execution",
+                          "api-reference/rest-apis/v2/approval-engine/executions/get-execution",
+                          "api-reference/rest-apis/v2/approval-engine/executions/cancel-execution",
+                          "api-reference/rest-apis/v2/approval-engine/executions/get-execution-events",
+                          "api-reference/rest-apis/v2/approval-engine/executions/list-executions"
+                        ]
+                      },
+                      {
+                        "group": "Steps",
+                        "pages": [
+                          "api-reference/rest-apis/v2/approval-engine/steps/record-reviewer-decision",
+                          "api-reference/rest-apis/v2/approval-engine/steps/record-agent-resolution",
+                          "api-reference/rest-apis/v2/approval-engine/steps/cancel-step",
+                          "api-reference/rest-apis/v2/approval-engine/steps/resolve-step"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Agents",
+                    "pages": [
+                      {
+                        "group": "Executions",
+                        "pages": [
+                          "api-reference/rest-apis/v2/agents/list-agent-executions"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Workspace",
+                    "pages": [
+                      {
+                        "group": "Account Creation and Verification",
+                        "pages": [
+                          "api-reference/rest-apis/v2/workspace/create",
+                          "api-reference/rest-apis/v2/workspace/get",
+                          "api-reference/rest-apis/v2/workspace/email-status",
+                          "api-reference/rest-apis/v2/workspace/send-login-link"
+                        ]
+                      },
+                      {
+                        "group": "API Key Management",
+                        "pages": [
+                          "api-reference/rest-apis/v2/workspace/apikey-create",
+                          "api-reference/rest-apis/v2/workspace/apikeys-get",
+                          "api-reference/rest-apis/v2/workspace/apikey-update"
+                        ]
+                      },
+                      {
+                        "group": "API Key Configuration",
+                        "pages": [
+                          "api-reference/rest-apis/v2/workspace/apikeyconfig-get",
+                          "api-reference/rest-apis/v2/workspace/apikeyconfig-update"
+                        ]
+                      },
+                      {
+                        "group": "Auth Tokens",
+                        "pages": [
+                          "api-reference/rest-apis/v2/workspace/authtokens-get",
+                          "api-reference/rest-apis/v2/workspace/authtoken-reset"
+                        ]
+                      },
+                      {
+                        "group": "Manage Domains",
+                        "pages": [
+                          "api-reference/rest-apis/v2/workspace/add-domain",
+                          "api-reference/rest-apis/v2/workspace/delete-domain",
+                          "api-reference/rest-apis/v2/workspace/domains-get"
+                        ]
+                      },
+                      {
+                        "group": "Email Notifications Configuration",
+                        "pages": [
+                          "api-reference/rest-apis/v2/workspace/emailconfig-get",
+                          "api-reference/rest-apis/v2/workspace/emailconfig-update"
+                        ]
+                      },
+                      {
+                        "group": "Webhooks Configuration",
+                        "pages": [
+                          "api-reference/rest-apis/v2/workspace/webhookconfig-get",
+                          "api-reference/rest-apis/v2/workspace/webhookconfig-update"
+                        ]
+                      },
+                      {
+                        "group": "Advanced Webhooks",
+                        "pages": [
+                          "api-reference/rest-apis/v2/workspace/advancedwebhookconfig-get",
+                          "api-reference/rest-apis/v2/workspace/advancedwebhookconfig-update",
+                          "api-reference/rest-apis/v2/workspace/advancedwebhook-endpoints-create",
+                          "api-reference/rest-apis/v2/workspace/advancedwebhook-endpoints-get",
+                          "api-reference/rest-apis/v2/workspace/advancedwebhook-endpoints-update",
+                          "api-reference/rest-apis/v2/workspace/advancedwebhook-endpoints-delete",
+                          "api-reference/rest-apis/v2/workspace/advancedwebhook-endpoints-secret-get"
+                        ]
+                      },
+                      {
+                        "group": "Activity Configuration",
+                        "pages": [
+                          "api-reference/rest-apis/v2/workspace/activityconfig-get",
+                          "api-reference/rest-apis/v2/workspace/activityconfig-update"
+                        ]
+                      },
+                      {
+                        "group": "Notification Configuration",
+                        "pages": [
+                          "api-reference/rest-apis/v2/workspace/notificationconfig-get",
+                          "api-reference/rest-apis/v2/workspace/notificationconfig-update"
+                        ]
+                      },
+                      {
+                        "group": "Permission Provider Configuration",
+                        "pages": [
+                          "api-reference/rest-apis/v2/workspace/permissionproviderconfig-get",
+                          "api-reference/rest-apis/v2/workspace/permissionproviderconfig-update"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "v1",
+                "pages": [
+                  {
+                    "group": "Organizations",
+                    "pages": [
+                      "api-reference/rest-apis/v1/organizations/add-organizations",
+                      "api-reference/rest-apis/v1/organizations/get-organizations",
+                      "api-reference/rest-apis/v1/organizations/update-organizations",
+                      "api-reference/rest-apis/v1/organizations/delete-organizations",
+                      "api-reference/rest-apis/v1/organizations/update-organization-disable-state"
+                    ]
+                  },
+                  {
+                    "group": "Folders",
+                    "pages": [
+                      "api-reference/rest-apis/v1/folders/add-folder",
+                      "api-reference/rest-apis/v1/folders/get-folders",
+                      "api-reference/rest-apis/v1/folders/update-folder",
+                      "api-reference/rest-apis/v1/folders/update-folder-access"
+                    ]
+                  },
+                  {
+                    "group": "Documents",
+                    "pages": [
+                      "api-reference/rest-apis/v1/documents/add-documents",
+                      "api-reference/rest-apis/v1/documents/get-documents",
+                      "api-reference/rest-apis/v1/documents/update-documents",
+                      "api-reference/rest-apis/v1/documents/delete-documents",
+                      "api-reference/rest-apis/v1/documents/move-documents",
+                      "api-reference/rest-apis/v1/documents/update-document-access",
+                      "api-reference/rest-apis/v1/documents/update-document-disable-state"
+                    ]
+                  },
+                  {
+                    "group": "Users",
+                    "pages": [
+                      "api-reference/rest-apis/v1/users/add-users",
+                      "api-reference/rest-apis/v1/users/get-users",
+                      "api-reference/rest-apis/v1/users/update-users",
+                      "api-reference/rest-apis/v1/users/delete-users"
+                    ]
+                  },
+                  {
+                    "group": "User Groups",
+                    "pages": [
+                      "api-reference/rest-apis/v1/user-groups/add-groups",
+                      "api-reference/rest-apis/v1/user-groups/add-users-to-group",
+                      "api-reference/rest-apis/v1/user-groups/delete-users-from-group"
+                    ]
+                  },
+                  {
+                    "group": "Comments Feature",
+                    "pages": [
+                      {
+                        "group": "Comments Annotations",
+                        "pages": [
+                          "api-reference/rest-apis/v1/comments-feature/comment-annotations/add-comment-annotations",
+                          "api-reference/rest-apis/v1/comments-feature/comment-annotations/get-comment-annotations",
+                          "api-reference/rest-apis/v1/comments-feature/comment-annotations/update-comment-annotations",
+                          "api-reference/rest-apis/v1/comments-feature/comment-annotations/delete-comment-annotations",
+                          "api-reference/rest-apis/v1/comments-feature/comment-annotations/get-comment-annotations-count"
+                        ]
+                      },
+                      {
+                        "group": "Comments",
+                        "pages": [
+                          "api-reference/rest-apis/v1/comments-feature/comments/add-comments",
+                          "api-reference/rest-apis/v1/comments-feature/comments/get-comments",
+                          "api-reference/rest-apis/v1/comments-feature/comments/update-comments",
+                          "api-reference/rest-apis/v1/comments-feature/comments/delete-comments"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Notifications",
+                    "pages": [
+                      "api-reference/rest-apis/v1/notifications/add-notifications",
+                      "api-reference/rest-apis/v1/notifications/get-notifications",
+                      "api-reference/rest-apis/v1/notifications/update-notifications",
+                      "api-reference/rest-apis/v1/notifications/delete-notifications",
+                      "api-reference/rest-apis/v1/notifications/set-config",
+                      "api-reference/rest-apis/v1/notifications/get-config"
+                    ]
+                  },
+                  {
+                    "group": "Access Control",
+                    "pages": [
+                      "api-reference/rest-apis/v1/auth/generate-token"
+                    ]
+                  },
+                  {
+                    "group": "GDPR",
+                    "pages": [
+                      "api-reference/rest-apis/v1/gdpr/get-all-user-data-gdpr",
+                      "api-reference/rest-apis/v1/gdpr/delete-all-user-data-gdpr",
+                      "api-reference/rest-apis/v1/gdpr/get-delete-user-data-status-gdpr"
+                    ]
+                  },
+                  {
+                    "group": "Live State",
+                    "pages": [
+                      "api-reference/rest-apis/v1/livestate/broadcast-event"
+                    ]
+                  },
+                  {
+                    "group": "Workspace",
+                    "pages": [
+                      "api-reference/rest-apis/v1/workspace/add-domain",
+                      "api-reference/rest-apis/v1/workspace/delete-domain"
+                    ]
                   }
                 ]
               }
             ]
-          }
-        ]
-      },
-      {
-        "tab": "Backend SDKs",
-        "groups": [
-          {
-            "group": "Node.js / TypeScript",
-            "pages": [
-              "backend-sdks/node"
-            ]
           },
           {
-            "group": "Python",
+            "group": "SDK",
             "pages": [
-              "backend-sdks/python"
+              {
+                "group": "APIs",
+                "pages": [
+                  "api-reference/sdk/api/api-methods",
+                  "api-reference/sdk/api/react-hooks"
+                ]
+              },
+              "api-reference/sdk/models/data-models"
             ]
           }
         ]
@@ -695,53 +1058,548 @@
         "tab": "Release Notes",
         "groups": [
           {
-            "group": "Version 5.0.0",
+            "group": "Release Notes",
             "pages": [
-              "release-notes/version-5/upgrade-guide",
-              "release-notes/version-5/sdk-changelog",
               {
-                "group": "CRDT Libraries Changelog",
+                "group": "Version 5.0.0",
                 "pages": [
-                  "release-notes/version-5/crdt-core-changelog"
+                  "release-notes/version-5/upgrade-guide",
+                  "release-notes/version-5/sdk-changelog",
+                  {
+                    "group": "CRDT Libraries Changelog",
+                    "pages": [
+                      "release-notes/version-5/crdt-core-changelog"
+                    ]
+                  },
+                  {
+                    "group": "Backend SDKs",
+                    "pages": [
+                      "release-notes/version-5/velt-py-changelog",
+                      "release-notes/version-5/velt-node-changelog",
+                      "release-notes/version-5/firebase-functions-changelog"
+                    ]
+                  }
                 ]
               },
               {
-                "group": "Backend SDKs",
+                "group": "Version 4.0.0",
                 "pages": [
-                  "release-notes/version-5/velt-py-changelog",
-                  "release-notes/version-5/velt-node-changelog",
-                  "release-notes/version-5/firebase-functions-changelog"
+                  "release-notes/version-4/upgrade-guide",
+                  "release-notes/version-4/sdk-changelog",
+                  {
+                    "group": "CRDT Libraries Changelog",
+                    "pages": [
+                      "release-notes/version-4/crdt-core-changelog",
+                      "release-notes/version-4/tiptap-changelog",
+                      "release-notes/version-4/blocknote-changelog",
+                      "release-notes/version-4/codemirror-changelog",
+                      "release-notes/version-4/reactflow-changelog"
+                    ]
+                  }
                 ]
-              }
-            ]
-          },
-          {
-            "group": "Version 4.0.0",
-            "pages": [
+              },
               "release-notes/3-0-0",
               {
-                "group": "Version 4.x SDK Changelog",
+                "group": "Version 2.0.0 and prior",
                 "pages": [
-                  "release-notes/version-4/sdk-changelog"
-                ]
-              },
-              {
-                "group": "CRDT Libraries Changelog",
-                "pages": [
-                  "release-notes/version-4/crdt-core-changelog"
-                ]
-              },
-              {
-                "group": "Backend SDKs",
-                "pages": [
-                  "release-notes/version-4/velt-py-changelog",
-                  "release-notes/version-4/velt-node-changelog"
+                  "release-notes/archive/aug-22-2024",
+                  "release-notes/archive/aug-21-2024",
+                  "release-notes/archive/aug-16-2024",
+                  "release-notes/archive/aug-14-2024",
+                  "release-notes/archive/aug-13-2024",
+                  "release-notes/archive/aug-12-2024",
+                  "release-notes/archive/aug-8-2024",
+                  "release-notes/archive/aug-6-2024",
+                  "release-notes/archive/july-09-2024",
+                  "release-notes/archive/july-04-2024",
+                  "release-notes/archive/july-03-2024",
+                  "release-notes/archive/july-02-2024",
+                  "release-notes/archive/june-30-2024",
+                  "release-notes/archive/june-29-2024",
+                  "release-notes/archive/june-24-2024",
+                  "release-notes/archive/june-10-2024",
+                  "release-notes/archive/june-6-2024",
+                  "release-notes/archive/may-29-2024",
+                  "release-notes/archive/may-24-2024",
+                  "release-notes/archive/may-23-2024",
+                  "release-notes/archive/may-17-2024",
+                  "release-notes/archive/may-10-2024",
+                  "release-notes/archive/april-24-2024",
+                  "release-notes/archive/april-16-2024",
+                  "release-notes/archive/march-14-2024",
+                  "release-notes/archive/march-5-2024",
+                  "release-notes/archive/feb-27-2024",
+                  "release-notes/archive/feb-20-2024",
+                  "release-notes/archive/feb-13-2024",
+                  "release-notes/archive/jan-14-2024",
+                  "release-notes/archive/dec-28-2023"
                 ]
               }
             ]
           }
         ]
+      },
+      {
+        "tab": "Examples",
+        "href": "https://velt.dev/examples"
+      },
+      {
+        "tab": "DevTools",
+        "href": "https://velt.dev/devtools"
       }
     ]
+  },
+  "redirects": [
+    {
+      "source": "/async-collaboration/comments-sidebar/setup",
+      "destination": "/async-collaboration/comments-sidebar/v1/setup"
+    },
+    {
+      "source": "/async-collaboration/comments-sidebar/customize-behavior",
+      "destination": "/async-collaboration/comments-sidebar/v1/customize-behavior"
+    },
+    {
+      "source": "/api-reference/rest-apis/v2/approval-engine/overview",
+      "destination": "/ai/approval-engine/overview"
+    },
+    {
+      "source": "/release-notes/version-4/changelog",
+      "destination": "/release-notes/version-4/sdk-changelog"
+    },
+    {
+      "source": "/notifications/email/overview",
+      "destination": "/async-collaboration/comments/notifications#email-notifications"
+    },
+    {
+      "source": "/get-started/setup/install",
+      "destination": "/get-started/quickstart"
+    },
+    {
+      "source": "/get-started/setup",
+      "destination": "/get-started/quickstart"
+    },
+    {
+      "source": "/ui-customization/features/async/notifications/notifications-tool",
+      "destination": "/ui-customization/features/async/notifications/notifications-tool/wireframes"
+    },
+    {
+      "source": "/ui-customization/features/async/notifications/notifications-panel",
+      "destination": "/ui-customization/features/async/notifications/notifications-panel/wireframes"
+    },
+    {
+      "source": "/ui-customization/features/async/notifications/notifications-primitives",
+      "destination": "/ui-customization/features/async/notifications/notifications-panel/primitives"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comment-bubble",
+      "destination": "/ui-customization/features/async/comments/comment-bubble/wireframes"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comment-pin",
+      "destination": "/ui-customization/features/async/comments/comment-pin/wireframes"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comment-sidebar-button",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar-button/wireframes"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/inline-comments-section",
+      "destination": "/ui-customization/features/async/comments/inline-comments-section/wireframes"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/multithread-comment-dialog",
+      "destination": "/ui-customization/features/async/comments/multithread-comments/wireframes"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/text-comment-tool",
+      "destination": "/ui-customization/features/async/comments/text-comment/text-comment-tool/wireframes"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/text-comment-toolbar",
+      "destination": "/ui-customization/features/async/comments/text-comment/text-comment-toolbar/wireframes"
+    },
+    {
+      "source": "/key-concepts/access-control/overview",
+      "destination": "/key-concepts/overview#access-control"
+    },
+    {
+      "source": "/get-started/setup/authenticate",
+      "destination": "/get-started/advanced#jwt-authentication-tokens"
+    },
+    {
+      "source": "/api-reference/api-methods/comments",
+      "destination": "/api-reference/sdk/api/api-methods"
+    },
+    {
+      "source": "/api-reference/hooks/hooks",
+      "destination": "/api-reference/sdk/api/react-hooks"
+    },
+    {
+      "source": "/api-reference/models/Comment",
+      "destination": "/api-reference/sdk/models/data-models"
+    },
+    {
+      "source": "/api-reference/models/CommentAnnotation",
+      "destination": "/api-reference/sdk/models/data-models"
+    },
+    {
+      "source": "/api-reference/models/RecorderData",
+      "destination": "/api-reference/sdk/models/data-models"
+    },
+    {
+      "source": "/api-reference/rest-apis",
+      "destination": "/api-reference/rest-apis/v2/workspace/create"
+    },
+    {
+      "source": "/api-reference/rest-apis/comments-feature/comment-annotations/get-comment-annotations-v2",
+      "destination": "/api-reference/rest-apis/v2/comments-feature/comment-annotations/get-comment-annotations-v2"
+    },
+    {
+      "source": "/api-reference/rest-apis/documents/add-documents",
+      "destination": "/api-reference/rest-apis/v2/documents/add-documents"
+    },
+    {
+      "source": "/api-reference/rest-apis/organizations/add-organizations",
+      "destination": "/api-reference/rest-apis/v2/organizations/add-organizations"
+    },
+    {
+      "source": "/async-collaboration/comment-thread/overview",
+      "destination": "/async-collaboration/comments/overview"
+    },
+    {
+      "source": "/async-collaboration/comments/customize-behavior/@mentions",
+      "destination": "/async-collaboration/comments/customize-behavior#mentions"
+    },
+    {
+      "source": "/async-collaboration/comments/customize-behavior/action-methods",
+      "destination": "/async-collaboration/comments/customize-behavior"
+    },
+    {
+      "source": "/async-collaboration/comments/customize-behavior/autocomplete",
+      "destination": "/async-collaboration/comments/customize-behavior"
+    },
+    {
+      "source": "/async-collaboration/comments/customize-behavior/custom-lists",
+      "destination": "/async-collaboration/comments/customize-behavior#custom-lists"
+    },
+    {
+      "source": "/async-collaboration/comments/customize-behavior/general-controls",
+      "destination": "/async-collaboration/comments/customize-behavior"
+    },
+    {
+      "source": "/async-collaboration/comments/customize-behavior/modes",
+      "destination": "/async-collaboration/comments/customize-behavior"
+    },
+    {
+      "source": "/async-collaboration/comments/customize-behavior/multimedia",
+      "destination": "/async-collaboration/comments/customize-behavior"
+    },
+    {
+      "source": "/async-collaboration/comments/customize-behavior/ui-controls",
+      "destination": "/async-collaboration/comments/customize-behavior"
+    },
+    {
+      "source": "/async-collaboration/comments/customize-behavior/visibility-controls",
+      "destination": "/async-collaboration/comments/customize-behavior"
+    },
+    {
+      "source": "/async-collaboration/notifications/api-add-notification",
+      "destination": "/async-collaboration/notifications/customize-behavior"
+    },
+    {
+      "source": "/key-concepts",
+      "destination": "/key-concepts/overview"
+    },
+    {
+      "source": "/key-concepts/client",
+      "destination": "/key-concepts/overview"
+    },
+    {
+      "source": "/key-concepts/organizations/setup",
+      "destination": "/key-concepts/overview#organizations"
+    },
+    {
+      "source": "/key-concepts/users/organization-user-groups",
+      "destination": "/key-concepts/overview#user-groups"
+    },
+    {
+      "source": "/key-concepts/locations/setup/api-update-location",
+      "destination": "/key-concepts/overview#locations"
+    },
+    {
+      "source": "/ui-customization/customize-css/remove-shadow-dom",
+      "destination": "/ui-customization/styling"
+    },
+    {
+      "source": "/ui-customization/customize-css/themes",
+      "destination": "/ui-customization/styling#themes"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comment-dialog-components",
+      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comment-dialog-primitives/overview",
+      "destination": "/ui-customization/features/async/comments/comment-dialog/primitives"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/autocomplete-chip-tooltip",
+      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/autocomplete-group-option",
+      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/autocomplete-option",
+      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/body/subcomponents/replyavatars",
+      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/body/subcomponents/threadcard",
+      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/body/subcomponents/togglereply",
+      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/header",
+      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes#header"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/navigation-button",
+      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/options-dropdown",
+      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/priority-dropdown",
+      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/reaction-pin",
+      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/reaction-pin-tooltip",
+      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/reaction-tool",
+      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/reactions-panel",
+      "destination": "/ui-customization/features/async/comments/comment-dialog/wireframes"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comment-dialog/subcomponents/status-dropdown",
+      "destination": "/ui-customication/features/async/comments/comment-dialog/wireframes"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comment-sidebar-components",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comment-sidebar-components-v2",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar-structure-v2"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comment-sidebar-componentscomment-sidebar-components",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar-structure-v2"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comments-sidebar/sidebar-button/overview",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar-button/wireframes"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comments-sidebar/sidebar-button/subcomponents/icon",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar-button/wireframes"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/overview",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/assigned",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/category",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/close-button",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/custom",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/done-button",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/filter-item",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/groupby",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/location",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/people",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/priority",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/reset-button",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/status",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/tagged",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/title",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/filter/subcomponents/versions",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/focused-thread",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar-structure-v2"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/header/overview",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/header/subcomponents/status/overview",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/header/subcomponents/status/subcomponents/content",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/header/subcomponents/status/subcomponents/trigger",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/list/overview",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/list/subcomponents/dialog-container",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/comments-sidebar/subcomponents/list/subcomponents/group",
+      "destination": "/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-components"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/confirm-dialog/overview",
+      "destination": "/ui-customization/features/async/comments/confirm-dialog"
+    },
+    {
+      "source": "/ui-customization/features/async/comments/inline-comments-section/subcomponents/panel/sorting-dropdown",
+      "destination": "/ui-customization/features/async/comments/inline-comments-section/wireframes"
+    },
+    {
+      "source": "/realtime-collaboration/presence/heartbeat",
+      "destination": "/realtime-collaboration/presence/overview#heartbeat-monitoring"
+    },
+    {
+      "source": "/ai-copilot/design/setup",
+      "destination": "/ai/rewriter/setup"
+    },
+    {
+      "source": "/users/client-side/setup",
+      "destination": "/key-concepts/overview#users"
+    },
+    {
+      "source": "/users/server-side/api-reset-contact-list",
+      "destination": "/api-reference/rest-apis/v2/users/delete-users"
+    }
+  ],
+  "logo": {
+    "light": "/velt-logo-big-light.png",
+    "dark": "/velt-logo-big.png",
+    "href": "https://docs.velt.dev"
+  },
+  "api": {
+    "playground": {
+      "display": "interactive"
+    }
+  },
+  "appearance": {
+    "default": "dark"
+  },
+  "background": {
+    "color": {
+      "dark": "#090014"
+    }
+  },
+  "navbar": {
+    "primary": {
+      "type": "button",
+      "label": "Get API Key",
+      "href": "https://console.velt.dev/"
+    }
+  },
+  "search": {
+    "prompt": "Search or ask..."
+  },
+  "contextual": {
+    "options": [
+      "copy",
+      "view",
+      "chatgpt",
+      "claude",
+      "perplexity"
+    ]
+  },
+  "seo": {
+    "metatags": {
+      "og:image": "https://firebasestorage.googleapis.com/v0/b/snippyly.appspot.com/o/external%2Fvelt_docs.png?alt=media&token=9e4502da-66ef-4005-9124-dbc76f04b1fd",
+      "twitter:image": "https://firebasestorage.googleapis.com/v0/b/snippyly.appspot.com/o/external%2Fvelt_docs.png?alt=media&token=9e4502da-66ef-4005-9124-dbc76f04b1fd",
+      "twitter:card": "summary_large_image"
+    },
+    "indexing": "all"
+  },
+  "footer": {
+    "socials": {
+      "twitter": "https://twitter.com/veltjs",
+      "linkedin": "https://www.linkedin.com/company/veltjs"
+    }
+  },
+  "integrations": {
+    "mixpanel": {
+      "projectToken": "6fe5c5cd3adeb341288776482e7bb147"
+    },
+    "intercom": {
+      "appId": "fxx14qnk"
+    }
   }
 }

--- a/release-notes/version-5/firebase-functions-changelog.mdx
+++ b/release-notes/version-5/firebase-functions-changelog.mdx
@@ -1,0 +1,100 @@
+---
+title: "Velt Firebase Functions Changelog"
+description: Release notes for Velt's shared Firebase backend platform (Approval Engine, Custom Agents, Platform Services)
+---
+
+### Platform Components
+- Approval Engine API
+- Custom Agents (SDK Functions)
+- Platform Services
+
+<Update label="June 23, 2026" description="Approval Engine & Agent Tooling">
+
+### Breaking Changes
+
+- **[Approval Engine]**: Removed the `onReject` per-human-node shorthand and the top-level `loops[]` array from the Approval Engine workflow contract. All routing — approve paths, reject paths, group fan-out/in, and loop-backs — must now be expressed through a unified `edges[]` array. Any definition that contains `HumanNodeConfig.onReject` or a top-level `loops[]` will be rejected at write time with `INVALID_ARGUMENT`. Existing in-flight executions and already-stored definitions are unaffected.
+
+  **Migration guide:**
+
+  | Old form | New `edges[]` equivalent |
+  |---|---|
+  | `"onReject": { "routeToNodeId": "rework-notice" }` | `{ "from": "human-review", "to": "rework-notice", "on": "reject" }` |
+  | `"onReject": { "loopBack": { "toNodeId": "agent-draft", "maxIterations": 3 } }` | `{ "from": "human-review", "to": "agent-draft", "on": "reject", "loop": { "maxIterations": 3 } }` |
+  | `"loops": [{ "entryNodeId": "agent-draft", "bodyNodeIds": [...], "maxIterations": 3 }]` | `{ "from": "human-review", "to": "agent-draft", "on": "reject", "loop": { "maxIterations": 3 } }` |
+  | `onReject.loopBack.onExhausted.routeToNodeId` | sibling `{ "from": "human-review", "to": "escalate", "on": "exhausted" }` edge |
+
+  **New `EdgeSchema` fields:**
+
+  | Field | Type | Required | Notes |
+  |---|---|---|---|
+  | `from` | `EdgeEndpoint` | yes | Bare string or `{ kind:"node", nodeId }` or `{ kind:"group", groupId }` |
+  | `to` | `EdgeEndpoint` | yes | Same |
+  | `on` | `"approve" \| "reject" \| "always" \| "exhausted" \| "custom"` | no (default `"always"`) | Semantic role |
+  | `when` | JSON-AST string | only for `on:"custom"` | Custom predicate |
+  | `loop` | `{ maxIterations: 1–20 }` | only on `on:"reject"` back-edge | Marks the edge as a loop-back |
+
+### New Features
+
+- **[Approval Engine]**: Every `DefinitionView` (from `create`, `get`, and `list`) now exposes a read-only `compiled` block. `compiled.forwardEdges` is the runtime edge list the engine drives execution from — group endpoints fully expanded and `on` roles compiled to predicate ASTs. `compiled.loops` contains server-derived loop regions. Clients building visual graph editors can consume `compiled.forwardEdges` directly instead of re-implementing group expansion client-side.
+
+  ```ts
+  interface CompiledGraph {
+    forwardEdges: Array<{
+      from: string;          // resolved node id
+      to: string;            // resolved node id
+      role: "approve" | "reject" | "always" | "exhausted" | "custom";
+      when: JsonAst | null;  // deterministic predicate AST; null for "always"
+      fromGroupId?: string;  // set when the authored `from` was a group
+      toGroupId?: string;    // set when the authored `to` was a group
+    }>;
+    loops: Array<{
+      loopId: string;
+      entryNodeId: string;
+      bodyNodeIds: string[];
+      maxIterations: number;
+      onExhausted: { routeToNodeId: string } | null;
+    }>;
+  }
+  ```
+
+- **[Approval Engine]**: `waitAll` groups can now be **edge sources** (`from: { kind:"group", groupId }`), giving them collective approve/reject fan-out with **unanimity** decision logic — `approve` if every member approved, `reject` otherwise. `cancelOnQuorum` groups can also be edge sources for collective approve fan-out. Group-to-node fan-out (`to: { kind:"group", groupId }`) is now accepted for all quorum policies.
+
+- **[Approval Engine]**: Human and agent nodes now accept optional `name` (1–200 chars) and `description` (max 2000 chars) fields, echoed verbatim in `NodeView`. These cosmetic fields let visual graph editors attach stable human-readable labels per node without affecting runtime behavior.
+
+- **[Custom Agents]**: Added `"rest-api"` context-gathering strategy. When configured, the agent fetches up to 10 customer-defined REST endpoints at execution time and injects the results into the prompt via the `{{restApiData}}` template variable. Supports `{{variable}}`, `{{userContext.X}}`, and `{{variables.X}}` templating in `url`, `headers`, `query`, and `body`. Auth secrets (`bearer`, `basic`, `header`) are encrypted at rest and redacted on every read.
+
+  | Field | Type | Required | Notes |
+  |---|---|---|---|
+  | `endpoints` | `RestApiEndpoint[]` | yes | 1–10 endpoints |
+  | `maxResponseBytes` | number | no | Per-endpoint cap. Default 1 000 000, max 5 000 000 |
+
+- **[Custom Agents]**: Added `"mcp-tools"` execution strategy. The agent connects to one or more customer-configured MCP servers (remote HTTP/Streamable HTTP transport), runs a capped multi-turn tool-calling loop, and returns a structured `CommonAgentResponse`. Supports per-server tool allowlists. Auth headers are encrypted at rest and redacted on read. Works with both Claude and Gemini providers.
+
+  ```json
+  {
+    "execution": {
+      "executionStrategy": "mcp-tools",
+      "mcpServers": [
+        {
+          "url": "https://docs.example.com/mcp",
+          "auth": { "type": "header", "headers": { "X-Api-Key": "sk_xxx" } },
+          "allowedTools": ["search_docs", "fetch_page"]
+        }
+      ]
+    }
+  }
+  ```
+
+- **[Custom Agents]**: Added `docs-code-comparison` built-in agent. Uses the MCP tool loop to verify code snippets on a landing page against the docs site and reports any mismatches as annotations.
+
+### Improvements
+
+- **[Custom Agents]**: `updateAgentConfig` now performs a **deep merge** instead of a shallow merge. Partial update calls now correctly preserve nested config fields (e.g., `execution.mcpServers`) not present in the update payload.
+
+- **[Custom Agents]**: `create` and `update-version` payloads now explicitly reject server-managed metadata fields (`managedBy`, `metadata.type`, `metadata.category`, `metadata.internal`, `metadata.apiKey`) with a per-field `400 INVALID_ARGUMENT` error.
+
+### Bug Fixes
+
+- **[Platform]**: Fixed non-deterministic project-card counts in email digests. The structured memory ask now runs at `temperature: 0`, the `recencyDays` recency window is anchored to UTC-day boundaries, and the grounding gate now keys only on deterministic signals (removing the `confidence` float). Two digest runs within the same UTC day over the same data will now produce identical project card counts and names.
+
+</Update>


### PR DESCRIPTION
## Summary

Syncs release notes from `snippyly/internal-release-notes` PR #6 (merged June 23, 2026).

**New file:** `release-notes/version-5/firebase-functions-changelog.mdx`
- Documents Velt's shared Firebase backend platform changes (Approval Engine, Custom Agents, Platform Services)
- Added to "Backend SDKs" navigation group under "Version 5.0.0" in Release Notes tab

**Changes in this release:**
- **Breaking**: Approval Engine unified `edges[]` array replaces `HumanNodeConfig.onReject` and top-level `loops[]`
- **New**: `compiled.forwardEdges` / `compiled.loops` on every `DefinitionView`
- **New**: `waitAll`/`cancelOnQuorum` groups as edge sources with collective fan-out
- **New**: Node `name` and `description` cosmetic fields
- **New**: `"rest-api"` context-gathering strategy for Custom Agents
- **New**: `"mcp-tools"` execution strategy for Custom Agents
- **New**: `docs-code-comparison` built-in agent
- **Improvement**: `updateAgentConfig` now performs deep merge
- **Improvement**: `create`/`update-version` reject server-managed metadata with `400 INVALID_ARGUMENT`
- **Bug Fix**: Fixed non-deterministic project-card counts in email digests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014kx9vYX7b1GD3FUKpWmRET)_