### PR TITLE
feat(release-notes): add v6.0.0-beta.1 and v6.0.0-beta.2 SDK changelog

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1061,6 +1061,12 @@
             "group": "Release Notes",
             "pages": [
               {
+                "group": "Version 6.0.0",
+                "pages": [
+                  "release-notes/version-6/sdk-changelog"
+                ]
+              },
+              {
                 "group": "Version 5.0.0",
                 "pages": [
                   "release-notes/version-5/upgrade-guide",

--- a/release-notes/version-6/sdk-changelog.mdx
+++ b/release-notes/version-6/sdk-changelog.mdx
@@ -1,0 +1,190 @@
+---
+title: "Velt SDK Changelog"
+rss: true
+description: Release Notes of changes added to the core Velt SDK
+---
+
+### Libraries
+- `@veltdev/react`
+- `@veltdev/client`
+- `@veltdev/sdk`
+
+<Update label="6.0.0-beta.2" description="June 24, 2026">
+
+### Breaking Changes
+
+- [**Comments**]: V2 comment sidebar events (`sidebarOpen`, `sidebarClose`, `commentClick`, `commentNavigationButtonClick`) are no longer emitted as `@Output()` callbacks on `<velt-comments-sidebar-v2>`. They must now be consumed via `commentElement.on()` (HTML) or `useCommentEventCallback()` (React). The React props `onSidebarOpen`, `onSidebarClose`, `onCommentClick`, and `onCommentNavigationButtonClick` have been removed from `VeltCommentsSidebarV2`. Only `onFullscreenClick` remains as an `@Output()` callback.
+
+<Tabs>
+<Tab title="React / Next.js">
+```tsx
+import { useCommentEventCallback } from '@veltdev/react';
+import { useEffect } from 'react';
+
+const sidebarOpen = useCommentEventCallback('sidebarOpen');
+useEffect(() => {
+  if (sidebarOpen) console.log('opened', sidebarOpen);
+}, [sidebarOpen]);
+
+const sidebarClose = useCommentEventCallback('sidebarClose');
+useEffect(() => {
+  if (sidebarClose) console.log('closed');
+}, [sidebarClose]);
+
+const commentClick = useCommentEventCallback('commentClick');
+useEffect(() => {
+  if (commentClick) console.log('comment clicked', commentClick.annotation);
+}, [commentClick]);
+
+const commentNav = useCommentEventCallback('commentNavigationButtonClick');
+useEffect(() => {
+  if (commentNav) console.log('nav', commentNav.annotation);
+}, [commentNav]);
+
+// onFullscreenClick is unchanged — still a prop callback:
+<VeltCommentsSidebarV2 onFullscreenClick={(data) => console.log('fullscreen', data)} />
+```
+</Tab>
+<Tab title="Other Frameworks">
+```js
+const commentElement = Velt.getCommentElement();
+
+commentElement.on('sidebarOpen').subscribe((data) => console.log('opened', data));
+commentElement.on('sidebarClose').subscribe(() => console.log('closed'));
+commentElement.on('commentClick').subscribe((data) => console.log('comment clicked', data?.annotation));
+commentElement.on('commentNavigationButtonClick').subscribe((data) => console.log('nav', data?.annotation));
+```
+</Tab>
+</Tabs>
+
+- [**Comments**]: The `sortData` / `sort-data` input has been removed from the V2 comment sidebar. Use `sortBy` / `sort-by` and `sortOrder` / `sort-order` instead.
+
+<Tabs>
+<Tab title="React / Next.js">
+```tsx
+{/* Before */}
+<VeltCommentsSidebarV2 sortData="asc" />
+
+{/* After */}
+<VeltCommentsSidebarV2 sortBy="lastUpdated" sortOrder="asc" />
+```
+</Tab>
+<Tab title="Other Frameworks">
+```html
+<!-- Before -->
+<velt-comments-sidebar-v2 sort-data="asc"></velt-comments-sidebar-v2>
+
+<!-- After -->
+<velt-comments-sidebar-v2 sort-by="lastUpdated" sort-order="asc"></velt-comments-sidebar-v2>
+```
+</Tab>
+</Tabs>
+
+- [**Comments**]: The deprecated `enableUrlNavigation` / `enable-url-navigation` input has been removed from the V2 comment sidebar. Use `urlNavigation` / `url-navigation` instead.
+
+<Tabs>
+<Tab title="React / Next.js">
+```tsx
+{/* Before */}
+<VeltCommentsSidebarV2 enableUrlNavigation={true} />
+
+{/* After */}
+<VeltCommentsSidebarV2 urlNavigation={true} />
+```
+</Tab>
+<Tab title="Other Frameworks">
+```html
+<!-- Before -->
+<velt-comments-sidebar-v2 enable-url-navigation="true"></velt-comments-sidebar-v2>
+
+<!-- After -->
+<velt-comments-sidebar-v2 url-navigation="true"></velt-comments-sidebar-v2>
+```
+</Tab>
+</Tabs>
+
+### New Features
+
+- [**Comments**]: Four new events added to `CommentEventTypes` and the `commentElement.on()` event bus: `sidebarOpen`, `sidebarClose`, `commentClick`, and `commentNavigationButtonClick`. These replace the removed V2 sidebar `@Output()` callbacks and deliver consistent payloads via `CommentEventTypesMap`.
+
+### Improvements
+
+- [**Comments**]: V2 comment sidebar filter option counts are now **absolute**. Each filter option's count reflects how many annotations match that option across the entire annotation universe and no longer shifts as other filters are applied.
+
+- [**Comments**]: Visual fixes in the V2 sidebar filter dropdown: the funnel icon is now themed for dark mode, the checkbox indicator is vertically aligned with its label, and only the checkbox (not the full row) picks up the accent color when a row is selected.
+
+### Bug Fixes
+
+- [**Comments**]: Fixed a P1 regression where `restricted` comments could silently drop programmatically-granted recipients on submit when using `commentElement.enablePrivateMode({ type: 'restricted', userIds: [...] })`. The recipient list is now derived from the lossless plaintext mirror rather than the contact-list-dependent picker state.
+
+- [**Comments**]: Reaction pins and the reaction tool now render and style correctly inside the comment dialog thread card again after the modular SDK switch to lazy custom elements in `6.0.0-beta.1`.
+
+- [**Comments**]: The `<velt-comments-sidebar-v2>` host element no longer reserves an invisible full-height block at its tag location. The sidebar now renders through a CDK overlay portal attached to `<body>` and is added/removed from the DOM on open/close. Embed/floating mode is unaffected.
+
+- [**Notifications**]: The notification-resolver org id now falls back to the organization config when not available from document paths, preventing resolved notification data from coming back empty.
+
+</Update>
+
+<Update label="6.0.0-beta.1" description="June 22, 2026">
+
+<Note>
+**Major architectural release.** The framework-agnostic `velt.js` bundle has been split into a small eager core plus on-demand, lazy-loaded feature chunks. The public Velt/Snippyly API is fully backward compatible — existing integrations continue to work unchanged.
+</Note>
+
+### New Features
+
+- [**Core**]: The SDK is now **modular**. Each feature is compiled into its own lazy-loaded chunk fetched on demand. If you do not pass a `featureAllowList`, all chunks are preloaded after init (preserving the pre-modular behavior). Opt in to the modular SDK by passing `featureAllowList` with only the features you use.
+
+<Tabs>
+<Tab title="React / Next.js">
+```tsx
+<VeltProvider
+  apiKey="YOUR_API_KEY"
+  initOptions={{ featureAllowList: ['comment', 'presence'] }}
+>
+  {/* app */}
+</VeltProvider>
+```
+</Tab>
+<Tab title="Other Frameworks">
+```js
+const Velt = await Velt.init('YOUR_API_KEY', {
+  featureAllowList: ['comment', 'presence'],
+});
+```
+</Tab>
+</Tabs>
+
+Features and their `featureAllowList` keys: `comment`, `cursor`, `presence`, `huddle`, `recorder`, `notification`, `reaction`, `arrow`, `tag`, `rewriter`, `selection`, `area`, `activity`, `views`, `userInvite`, `userRequest`, `videoPlayer`, `crdt`, `liveStateSync`.
+
+- [**Core**]: New `preload*()` methods on the Velt/Snippyly facade give explicit, per-feature control over when each chunk is fetched. All methods are idempotent and resolve once the chunk is loaded and its custom elements are registered. Particularly useful for tag-only features (`userInvite`, `userRequest`, `videoPlayer`) that have no `getXElement()` accessor.
+
+<Tabs>
+<Tab title="React / Next.js">
+```tsx
+// Warm up the comment chunk, then open the sidebar instantly
+await client.preloadComment();
+client.getCommentElement().openCommentSidebar();
+```
+</Tab>
+<Tab title="Other Frameworks">
+```js
+// Tag-only feature: preload so the <velt-user-request-tool> tag upgrades
+await Velt.preloadUserRequest();
+```
+</Tab>
+</Tabs>
+
+### Improvements
+
+- [**Core**]: Every `getXElement()` accessor now returns a non-blocking lazy facade immediately. Void method calls are queued and flushed once the chunk loads; Promise-returning methods await the chunk; Observable / `on()` event subscriptions bridge via a `ReplaySubject` — so all existing code works identically whether or not the chunk has loaded.
+
+- [**Recorder**]: Transcription is now folded into the recorder chunk (`velt-recorder.js`). Loading the recorder feature also makes transcription and subtitle embed elements available.
+
+### Bug Fixes
+
+- [**Video Player**]: Fixed subtitles and transcription silently not working when the recorder chunk was deferred. The video player now proactively loads the recorder chunk when transcription or subtitle embeds are needed.
+
+- [**Reactions**]: Fixed the active-state highlight (active CSS class and `aria-pressed`) for the current user's reaction pin on `<velt-reaction-pin>`. Swapping the `annotationId` input no longer tears down the user subscription before it can emit.
+
+</Update>


### PR DESCRIPTION
## Summary

Syncs the two new v6 release notes from `snippyly/internal-release-notes` into the Velt docs.

### Changes

- **New file**: `release-notes/version-6/sdk-changelog.mdx` — versioned changelog for the v6.0.0 beta series, covering both beta releases:
  - **v6.0.0-beta.2** (June 24, 2026): Breaking changes, API additions, improvements, and bug fixes
  - **v6.0.0-beta.1** (June 22, 2026): Major architectural release introducing modular SDK with lazy-loaded feature chunks
- **Updated**: `docs.json` — added `"Version 6.0.0"` navigation group as the first entry under the Release Notes tab, before the existing Version 5.0.0 group

### v6.0.0-beta.2 highlights
- **Breaking**: V2 sidebar events (`onSidebarOpen`, `onSidebarClose`, `onCommentClick`, `onCommentNavigationButtonClick`) moved from `@Output()` props to the `commentElement.on()` event bus
- **Breaking**: `sortData`/`sort-data` removed — use `sortBy`/`sortOrder` instead
- **Breaking**: `enableUrlNavigation`/`enable-url-navigation` removed — use `urlNavigation`/`url-navigation` instead
- **New**: 4 new `CommentEventTypes` entries: `sidebarOpen`, `sidebarClose`, `commentClick`, `commentNavigationButtonClick`

### v6.0.0-beta.1 highlights
- **New**: Modular SDK architecture with `featureAllowList` at init for lazy-loaded feature chunks
- **New**: `preload*()` methods for all features
- **Improved**: `getXElement()` lazy facades; transcription folded into recorder chunk

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcYagSz73GSw875QDjFata)_