### PR TITLE
ci: notify Slack for release-note PRs

### DIFF
--- a/.github/release-note-pipeline/README.md
+++ b/.github/release-note-pipeline/README.md
@@ -4,7 +4,9 @@ When a Markdown release note changes in
 `snippyly/internal-release-notes/release-notes/**`, the source repo dispatches
 an event to `velt-js/docs`. The docs workflow classifies the note, creates or
 reuses the right PR branch, and runs the committed release-note agents
-sequentially on Opus 4.8 with checkpoints after every stage.
+sequentially on Opus 4.8 with checkpoints after every stage. When the runner
+creates a new draft PR, it can also post a non-blocking Slack notification to
+`#docs-automation`.
 
 ## Flow
 
@@ -93,10 +95,14 @@ bash scripts/release-notes/test-detector.sh
 bash scripts/release-notes/test-url-parser.sh
 bash scripts/release-notes/test-resolver.sh
 bash scripts/release-notes/test-internal-trim.sh
+bash scripts/release-notes/test-slack-payload.sh
 ```
 
 ## Required secrets
 
 - `velt-js/docs`: `ANTHROPIC_API_KEY`, `CROSS_REPO_PAT`.
+- `velt-js/docs`: optional `DOCS_AUTOMATION_SLACK_WEBHOOK_URL`, an incoming
+  webhook configured for the `#docs-automation` channel. If missing or
+  temporarily failing, the runner logs the Slack failure and continues.
 - `snippyly/internal-release-notes`: `DOCS_DISPATCH_PAT` with access to
   dispatch workflows and create fallback issues in `velt-js/docs`.

--- a/.github/workflows/release-note-to-docs-pr.yml
+++ b/.github/workflows/release-note-to-docs-pr.yml
@@ -158,6 +158,7 @@ jobs:
           AGENT_MAX_TURNS:   "100"
           RUN_URL:           ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           DOCS_REPO:         ${{ env.DOCS_REPO }}
+          SLACK_WEBHOOK_URL: ${{ secrets.DOCS_AUTOMATION_SLACK_WEBHOOK_URL }}
           ANTHROPIC_DEFAULT_OPUS_MODEL: claude-opus-4-8
         run: bash scripts/release-notes/run-release-note-pipeline.sh
 

--- a/scripts/release-notes/lib.sh
+++ b/scripts/release-notes/lib.sh
@@ -168,6 +168,69 @@ rn_route_json() {
     }'
 }
 
+rn_slack_pr_payload() {
+  local pr_url="${1:?pr url is required}"
+  local pr_number="${2:?pr number is required}"
+  local pr_title="${3:?pr title is required}"
+  local note_path="${4:?note path is required}"
+  local route="${5:?route is required}"
+  local source_url="${6:?source url is required}"
+  local run_url="${7:-}"
+  local status="${8:-In progress}"
+  local run_text="not provided"
+
+  if [ -n "$run_url" ]; then
+    run_text="<$run_url|GitHub Actions run>"
+  fi
+
+  jq -n \
+    --arg pr_url "$pr_url" \
+    --arg pr_number "$pr_number" \
+    --arg pr_title "$pr_title" \
+    --arg note_path "$note_path" \
+    --arg route "$route" \
+    --arg source_url "$source_url" \
+    --arg run_text "$run_text" \
+    --arg status "$status" \
+    '{
+      text: "Release-note docs PR created: #\($pr_number) \($pr_title)",
+      blocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: "*Release-note docs PR created*\n<\($pr_url)|#\($pr_number) \($pr_title)>"
+          }
+        },
+        {
+          type: "section",
+          fields: [
+            {
+              type: "mrkdwn",
+              text: "*Release note:*\n`\($note_path)`"
+            },
+            {
+              type: "mrkdwn",
+              text: "*Route:*\n`\($route)`"
+            },
+            {
+              type: "mrkdwn",
+              text: "*Source:*\n<\($source_url)|release note>"
+            },
+            {
+              type: "mrkdwn",
+              text: "*Run:*\n\($run_text)"
+            },
+            {
+              type: "mrkdwn",
+              text: "*Status:*\n\($status)"
+            }
+          ]
+        }
+      ]
+    }'
+}
+
 rn_is_core_release_branch() {
   local branch="${1:?branch is required}"
   [[ "$branch" =~ ^v[0-9] ]]

--- a/scripts/release-notes/run-release-note-pipeline.sh
+++ b/scripts/release-notes/run-release-note-pipeline.sh
@@ -22,6 +22,7 @@ MODE="${PIPELINE_MODE:-auto}"
 DRY_RUN="${PIPELINE_DRY_RUN:-false}"
 MODEL="${PIPELINE_MODEL:-claude-opus-4-8}"
 RUN_URL="${RUN_URL:-}"
+SLACK_WEBHOOK_URL="${SLACK_WEBHOOK_URL:-}"
 DOCS_ROOT="$PWD"
 
 case "$MODE" in
@@ -207,6 +208,44 @@ create_issue() {
   gh issue create --repo "$DOCS_REPO" --title "$title" --body "$body" --label documentation || true
 }
 
+notify_slack_pr_created() {
+  local status="$1"
+  local payload_file
+
+  if [ "$DRY_RUN" = "true" ]; then
+    log "Dry run: would notify Slack about PR #${PR_NUMBER:-unknown}"
+    return 0
+  fi
+
+  if [ -z "$SLACK_WEBHOOK_URL" ]; then
+    log "Slack notification skipped: DOCS_AUTOMATION_SLACK_WEBHOOK_URL is not configured"
+    return 0
+  fi
+
+  payload_file="${RUNNER_TEMP:-/tmp}/release-note-pr-${PR_NUMBER}.slack.json"
+  rn_slack_pr_payload \
+    "$PR_URL" \
+    "$PR_NUMBER" \
+    "$RN_TITLE" \
+    "$NOTE_PATH" \
+    "$RN_CLASS" \
+    "$(source_note_url)" \
+    "$RUN_URL" \
+    "$status" > "$payload_file"
+
+  if curl -fsS \
+    -X POST \
+    -H 'Content-Type: application/json; charset=utf-8' \
+    --data-binary "@${payload_file}" \
+    "$SLACK_WEBHOOK_URL" >/dev/null; then
+    log "Notified Slack for PR #$PR_NUMBER"
+  else
+    log "Slack notification failed for PR #$PR_NUMBER; continuing without failing the release-note pipeline"
+  fi
+
+  rm -f "$payload_file"
+}
+
 ensure_pr_for_current_branch() {
   local status="$1"
   local existing body_file url pr_json
@@ -245,6 +284,7 @@ ensure_pr_for_current_branch() {
   pr_json="$(gh pr view "$url" --repo "$DOCS_REPO" --json number,url)"
   PR_NUMBER="$(printf '%s' "$pr_json" | jq -r '.number')"
   log "Created draft PR #$PR_NUMBER: $PR_URL"
+  notify_slack_pr_created "$status"
 }
 
 notify_failure() {

--- a/scripts/release-notes/test-slack-payload.sh
+++ b/scripts/release-notes/test-slack-payload.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+payload="$(rn_slack_pr_payload \
+  "https://github.com/velt-js/docs/pull/123" \
+  "123" \
+  "v6.0.0-beta.2" \
+  "release-notes/v6.0.0-beta.2.md" \
+  "core-SDK" \
+  "https://github.com/snippyly/internal-release-notes/blob/main/release-notes/v6.0.0-beta.2.md" \
+  "https://github.com/velt-js/docs/actions/runs/1234567890" \
+  "In progress")"
+
+printf '%s\n' "$payload" | jq -e . >/dev/null
+
+assert_jq() {
+  local name="$1"
+  local filter="$2"
+
+  if printf '%s\n' "$payload" | jq -e "$filter" >/dev/null; then
+    printf '  ok  %s\n' "$name"
+  else
+    printf '  FAIL %s\n' "$name" >&2
+    printf '%s\n' "$payload" >&2
+    exit 1
+  fi
+}
+
+assert_jq "fallback text includes PR number" '.text | contains("#123")'
+assert_jq "payload links PR" '[.. | strings] | any(.[] ; contains("<https://github.com/velt-js/docs/pull/123|#123 v6.0.0-beta.2"))'
+assert_jq "payload includes note path" '[.. | strings] | any(.[] ; contains("release-notes/v6.0.0-beta.2.md"))'
+assert_jq "payload includes route" '[.. | strings] | any(.[] ; contains("core-SDK"))'
+assert_jq "payload includes run link" '[.. | strings] | any(.[] ; contains("GitHub Actions run"))'
+
+printf '\n[test-slack-payload] OK\n'


### PR DESCRIPTION
## Summary

- Post a non-blocking Slack notification when the release-note runner creates a new draft docs PR.
- Expose the optional `DOCS_AUTOMATION_SLACK_WEBHOOK_URL` secret to the runner.
- Add an offline Slack payload test and document the secret for `#docs-automation`.

## Tests

- `bash -n scripts/release-notes/lib.sh scripts/release-notes/run-release-note-pipeline.sh scripts/release-notes/test-slack-payload.sh`
- `bash scripts/release-notes/test-routing.sh && bash scripts/release-notes/test-detector.sh && bash scripts/release-notes/test-url-parser.sh && bash scripts/release-notes/test-resolver.sh && bash scripts/release-notes/test-internal-trim.sh && bash scripts/release-notes/test-slack-payload.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-note-to-docs-pr.yml"); puts "workflow yaml ok"'`