### PR TITLE
ci: keep release-note runtime across branch checkout

### DIFF
--- a/scripts/release-notes/run-release-note-agent.sh
+++ b/scripts/release-notes/run-release-note-agent.sh
@@ -19,9 +19,10 @@ STAGE="${2:?stage id is required, e.g. 01-agent-1}"
 MODEL="${PIPELINE_MODEL:-claude-opus-4-8}"
 MAX_TURNS="${AGENT_MAX_TURNS:-80}"
 DOCS_ROOT="${DOCS_ROOT:-$PWD}"
+AGENTS_ROOT="${AGENTS_ROOT:-$DOCS_ROOT/.claude/agents}"
 
 shopt -s nullglob
-AGENT_FILES=( "$DOCS_ROOT"/.claude/agents/Agent-*-"${AGENT}".md )
+AGENT_FILES=( "$AGENTS_ROOT"/Agent-*-"${AGENT}".md )
 shopt -u nullglob
 
 if [ "${#AGENT_FILES[@]}" -eq 0 ]; then

--- a/scripts/release-notes/run-release-note-pipeline.sh
+++ b/scripts/release-notes/run-release-note-pipeline.sh
@@ -34,7 +34,25 @@ if [ "$MODE" = "auto" ] && { [ "$CHANGE_TYPE" = "modified" ] || [ "$CHANGE_TYPE"
   MODE="force"
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BOOTSTRAP_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNTIME_ROOT="${RUNNER_TEMP:-/tmp}/release-note-pipeline-runtime-${GITHUB_RUN_ID:-$$}"
+SCRIPT_DIR="$RUNTIME_ROOT/scripts"
+AGENTS_ROOT="$RUNTIME_ROOT/agents"
+AGENT_SOURCES=()
+
+rm -rf "$RUNTIME_ROOT"
+mkdir -p "$SCRIPT_DIR" "$AGENTS_ROOT"
+cp "$BOOTSTRAP_SCRIPT_DIR"/*.sh "$SCRIPT_DIR/"
+
+if [ -d "$DOCS_ROOT/.claude/agents" ]; then
+  shopt -s nullglob
+  AGENT_SOURCES=( "$DOCS_ROOT"/.claude/agents/Agent-*.md )
+  shopt -u nullglob
+  if [ "${#AGENT_SOURCES[@]}" -gt 0 ]; then
+    cp "${AGENT_SOURCES[@]}" "$AGENTS_ROOT/"
+  fi
+fi
+
 # shellcheck source=./lib.sh
 source "$SCRIPT_DIR/lib.sh"
 
@@ -408,6 +426,7 @@ run_agent_stage() {
     RN_CHANGELOG="$RN_CHANGELOG" \
     BACKEND_ONLY="$BACKEND_ONLY" \
     ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-}" \
+    AGENTS_ROOT="$AGENTS_ROOT" \
     SOURCE_DIR="$SOURCE_DIR" \
     NOTE_PATH="$NOTE_PATH" \
     PIPELINE_MODEL="$MODEL" \


### PR DESCRIPTION
## Summary

- Snapshot release-note runner scripts and agent prompts into the Actions temp directory before checking out any target PR branch.
- Teach the agent wrapper to read agent prompts from that runtime snapshot.
- Fixes the failed run where the existing `v6.0.0-beta.2` branch did not contain the new automation scripts, causing Agent 1 to fail before Claude ran.

## Failed run fixed

- https://github.com/velt-js/docs/actions/runs/28146717779

## Tests

- `bash -n scripts/release-notes/run-release-note-pipeline.sh scripts/release-notes/run-release-note-agent.sh`
- `bash scripts/release-notes/test-routing.sh && bash scripts/release-notes/test-detector.sh && bash scripts/release-notes/test-url-parser.sh && bash scripts/release-notes/test-resolver.sh && bash scripts/release-notes/test-internal-trim.sh && bash scripts/release-notes/test-slack-payload.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-note-to-docs-pr.yml"); puts "workflow yaml ok"'`