### PR TITLE
ci: avoid duplicate release-note failure issues

### DIFF
--- a/.github/workflows/release-note-to-docs-pr.yml
+++ b/.github/workflows/release-note-to-docs-pr.yml
@@ -167,6 +167,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.CROSS_REPO_PAT }}
         run: |
+          if [ -f "${RUNNER_TEMP}/release-note-failure-notified" ]; then
+            echo "Release-note runner already posted failure notification:"
+            cat "${RUNNER_TEMP}/release-note-failure-notified"
+            exit 0
+          fi
+
           NOTE_PATH="${{ steps.inputs.outputs.note_path || inputs.path || inputs.release_note_url || github.event.client_payload.path || github.event.client_payload.release_note_url }}"
           NOTE_URL="${{ steps.inputs.outputs.source_note_url || inputs.release_note_url || github.event.client_payload.release_note_url }}"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/scripts/release-notes/run-release-note-pipeline.sh
+++ b/scripts/release-notes/run-release-note-pipeline.sh
@@ -23,6 +23,7 @@ DRY_RUN="${PIPELINE_DRY_RUN:-false}"
 MODEL="${PIPELINE_MODEL:-claude-opus-4-8}"
 RUN_URL="${RUN_URL:-}"
 SLACK_WEBHOOK_URL="${SLACK_WEBHOOK_URL:-}"
+FAILURE_NOTIFIED_FILE="${FAILURE_NOTIFIED_FILE:-${RUNNER_TEMP:-/tmp}/release-note-failure-notified}"
 DOCS_ROOT="$PWD"
 
 case "$MODE" in
@@ -324,6 +325,12 @@ Rerun with release_note_url: $(source_note_url)
   else
     create_issue "release-note pipeline failed: ${NOTE_PATH}" "$body"
   fi
+
+  mkdir -p "$(dirname "$FAILURE_NOTIFIED_FILE")"
+  {
+    printf 'notified_at=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    printf 'stage=%q\n' "$stage"
+  } > "$FAILURE_NOTIFIED_FILE"
 }
 
 checkout_branch() {


### PR DESCRIPTION
## Summary

- Mark failures as already notified when the release-note runner comments on a PR or creates its own issue.
- Make the workflow-level fallback skip duplicate issue creation when that marker exists.

## Context

Run https://github.com/velt-js/docs/actions/runs/28146876179 correctly commented on PR #255 after reaching Claude, but the workflow fallback also opened a duplicate issue saying no PR was produced.

## Tests

- `bash -n scripts/release-notes/run-release-note-pipeline.sh`
- `bash scripts/release-notes/test-routing.sh && bash scripts/release-notes/test-detector.sh && bash scripts/release-notes/test-url-parser.sh && bash scripts/release-notes/test-resolver.sh && bash scripts/release-notes/test-internal-trim.sh && bash scripts/release-notes/test-slack-payload.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-note-to-docs-pr.yml"); puts "workflow yaml ok"'`