### PR TITLE
v6.0.0-beta.4

### DIFF
--- a/.claude/release-notes/input-v6.0.0-beta.4.md
+++ b/.claude/release-notes/input-v6.0.0-beta.4.md
@@ -1,0 +1,161 @@
+# Velt SDK Release Notes - v6.0.0-beta.4
+Release Date: July 02, 2026
+
+## Summary
+| SDK | Files Changed | Insertions | Deletions |
+|-----|--------------|------------|-----------|
+| HTML/Vanilla (sdk) | 15 | +2054 | -202 |
+| React (sdk-react) | 3 | +4 | -4 |
+
+> This release is focused entirely on the **Comment Sidebar V2** (`<velt-comments-sidebar-v2>`): a set of grouping, filtering, and counting behavior fixes that bring V2 to parity with the V1 comment sidebar. There are no new public API methods and no breaking changes to the public API surface. The React SDK change is a version bump only (see Internal).
+
+## Improvements
+
+### 1. Sidebar List Group Expand/Collapse: Current-Page-First Defaults + Persistent Overrides
+
+**What:** When the Comment Sidebar V2 list is grouped by **location** or **document**, only the current page's (or current document's) group is now expanded by default; all other groups start collapsed — matching V1. Additional locations (set via multiple locations / `addLocation`) also default to expanded. Every other grouping (e.g. status, priority, a custom field) still defaults to all groups expanded. On top of the defaults, the sidebar now tracks both user **collapse** and user **expand** actions independently and persists them to `sessionStorage`, so a group you explicitly opened or closed stays that way across reloads.
+
+**Why:** Previously the sidebar only tracked collapsed groups, so it could not represent "a default-collapsed group the user explicitly expanded," and grouping by location/document always started fully expanded — a long list of pages opened all at once instead of focusing on the current page (V1 behavior).
+
+**Impact:** Grouped lists open focused on the page/document the user is on. Expand/collapse choices survive a reload. A **real** location switch (page A → page B) resets the toggles so the new current page auto-expands (V1 parity), but a reload's baseline-establishing location emission (undefined → the same page) preserves the restored toggles instead of wiping them. Group expansion is resolved with a stable precedence everywhere: user-expanded override → user-collapsed override → per-grouping default.
+
+---
+
+### 2. Default Status Filter Selection (Open + In Progress)
+
+**What:** On first load, the Comment Sidebar V2 Status filter now starts with **Open** (the default status) and every **In Progress** (ongoing) status pre-selected, so resolved/terminal comments are hidden by an explicit, visible, clearable selection rather than an invisible preset — matching V1's `setDefaultStatuses`.
+
+**Why:** V2 previously hid resolved comments through an implicit "all" quick-filter preset, which was neither visible nor clearable in the filter UI and diverged from V1's behavior of showing the active status selection as checked options.
+
+**Impact:** The Status section shows Open + In Progress as checked on load. The seed is skipped when `sessionStorage` state was restored, when the client provided a status filter via `setCommentSidebarFilters`, or once the user has touched the selection. If the status catalog loads late (e.g. console-configured statuses), an untouched seed refreshes to the new catalog's default/ongoing ids. Clearing the selection (see Bug Fix #4) reveals resolved comments.
+
+---
+
+### 3. `setCommentSidebarFilters` Now Applies as Clearable Selected Filters (with Stable Facet Counts)
+
+**What:** Client-provided sidebar filters — the `setCommentSidebarFilters(...)` API and the V1-shape `filters` input — now map onto the sidebar's own **selected filter state** (V1 `mergeClientFilters` parity) instead of being applied as a separate hard "system filter" stage. The passed values render as **checked options** in the filter panel, are cleared by **Reset**, and merge per key (a later call with only `location` keeps the existing `involved` selection; a present-but-empty array clears just that field; an empty object `{}` clears all selections).
+
+**Why:** As a hard system stage, client filters silently shrank the facet-count universe, so filter option counts shifted based on what the integration had pushed and the applied filters were invisible/unclearable in the UI. V1 instead surfaces client filters as ordinary selected options.
+
+**Impact:** Facet option counts are now **absolute within the page-scoped universe** and no longer shrink when client filters are applied — every option keeps showing (with the client-applied ones checked). The Main Filter badge count reflects the applied client selections, and Reset clears them. Filter values map correctly: locations by identity key (id, falling back to name), people/assigned/tagged/involved by `userId` (email fallback), status/priority/category verbatim, `accessModes` onto comment type, `version` by id, and custom field keys (strings or `{id,name}` objects).
+
+**API (React + HTML — identical):**
+
+Declared signature (unchanged in this release — behavior fix only):
+```ts
+setCommentSidebarFilters(filters: CommentSidebarFilters): void;
+```
+
+Usage:
+```ts
+const commentElement = client.getCommentElement();
+
+// Applied as selected (checked) filter options; Reset clears them.
+commentElement.setCommentSidebarFilters({
+  status: ['OPEN'],
+  involved: [{ userId: 'user-123' }],
+  location: [{ id: 'locationA', locationName: 'Location A' }],
+});
+
+// A present-but-empty array clears just that field:
+commentElement.setCommentSidebarFilters({ location: [] });
+
+// An empty object clears ALL selections:
+commentElement.setCommentSidebarFilters({});
+```
+
+---
+
+## Bug Fixes
+
+### 1. Name-Only Locations Now Scope Sidebar Grouping, Filtering, and Page Mode
+
+**What:** A single source of truth for location identity was introduced (`getLocationKey` / `getAnnotationLocationKey` / `getAnnotationLocationLabel` / `normalizeLocationValue`) and every "which page is this" consumer in the sidebar — grouping, the location filter's options + matching, page mode (`page-mode="true"`), and client filters — now derives its key through it. A location's identity is its `id`, **falling back to `locationName`** for id-less locations (name-only `setLocation` / `documentParams` pages). Annotation `location.id`s that are numeric are coerced to strings so they compare equal to the string group keys.
+
+**Why:** V2 read `location.id` directly in several places, so a location created with a name but no id (`setLocation({ locationName: 'Home' })`) produced no key — it silently broke that specific feature (page mode showed every page, the location filter had no option, the group didn't default-expand) while the rest kept working.
+
+**Impact:** Name-only locations now behave identically to id-based ones: the location filter lists them and matches them, page mode scopes the list to them, and their group default-expands. Annotations with no location context at all fall into the catch-all "Others" bucket. Falsy-but-valid ids (`0`) are preserved; `null` / `undefined` / empty-string ids fall back to the name. When an annotation has both an id and a name, the id wins consistently across all consumers.
+
+---
+
+### 2. Duplicate People in the People / Involved / Assigned / Tagged Filters
+
+**What:** Filter options for user fields (people, involved, assigned, tagged) are now keyed **strictly by `userId`**. Occurrences of a person that carry only an email (e.g. someone tagged by email before signing up, or an author record with only an email) no longer create a second option.
+
+**Why:** Options were previously keyed by `userId || email`, so the same human referenced with a `userId` on some records and email-only on others produced **two** options — a userId-keyed one and an email-keyed twin — with diverging counts. The email-keyed twin could never count correctly because the assigned/tagged predicates match by `userId` only.
+
+**Impact:** One option per person, keyed by `userId`, with counts and filtering that match V1. The option is labeled name-first with an email fallback (`name || email`). Email-only assignees/tagged contacts (with no `userId`) never become options — the same as V1.
+
+---
+
+### 3. Sidebar Button "filter" Count Badge Reflects the Actual Filtered List
+
+**What:** The Comment Sidebar V2 now publishes its filtered list to `CommentService.commentsFromSidebarMap` on every pipeline run (V1 parity). This map is read by the sidebar-button's `count-type='filter'` badge and by the filter-comments-on-DOM pin gate.
+
+**Why:** Without publishing, both consumers silently fell back to counting/showing **all** annotations — so the badge could read (e.g.) 129 while the sidebar itself was empty, and DOM pins were not gated by the sidebar's filter state.
+
+**Impact:** With `setSidebarButtonCountType('filter')`, the badge count now matches the filtered sidebar list (including an empty list showing 0, and deletions decrementing the count). While the sidebar is skeleton-loading, the existing map is preserved (V1 parity). When the sidebar is destroyed, the map is reset so a removed sidebar stops gating the badge and DOM pins.
+
+Declared signature (unchanged in this release — behavior fix only):
+```ts
+setSidebarButtonCountType(type: string): void;
+// Evidenced call-site value: 'filter' (also settable via the count-type='filter' HTML attribute)
+```
+
+Usage:
+```ts
+const commentElement = client.getCommentElement();
+commentElement.setSidebarButtonCountType('filter'); // badge now counts the filtered list
+```
+
+---
+
+### 4. Clearing Filters / Selecting "All" on Status Now Shows Resolved Comments
+
+**What:** Explicitly choosing **"All"** on the Status field, or hitting **Reset**, now shows resolved/terminal comments (V1 parity: `updateFilter('statuses', all=true)` → `resolvedCommentsOnDom = true`).
+
+**Why:** V2's "all" quick-filter preset kept hiding terminal statuses even after the user cleared the status filter, so resolved comments stayed hidden when the user expected "show everything."
+
+**Impact:** Clearing the Status selection or resetting all filters reveals resolved comments. Clearing a non-status field does not touch the resolved flag. Reset also clears any seeded/default status selection and does not re-trigger the Open + In Progress seed afterward.
+
+---
+
+### 5. Priority Filter Shows a "Not Set" Bucket
+
+**What:** The default Priority section in the Main Filter panel now surfaces an **unset** bucket labeled **"Not set"** for comments that have no priority (V1's `unsetType { id: 'unset', name: 'Not set' }`).
+
+**Why:** V2 built the default Priority field with `includeUnset: false`, so comments without a priority could not be filtered for and diverged from V1, which always shows the "Not set" option.
+
+**Impact:** Comments without a priority are now filterable via the "Not set" option. The unset bucket is labeled "Not set" (not the generic "None"). Fields configured with `includeUnset: false` still omit the bucket.
+
+---
+
+### 6. Client Filters for Fields Not Shown in the Panel Now Filter
+
+**What:** When `setCommentSidebarFilters` pushes a selection for a field that is **not** declared/displayed anywhere (e.g. a `version` filter when Version isn't a Main Filter panel section), the sidebar now synthesizes a field descriptor for it so the selection actually filters the list — V1 applies client filters regardless of what the panel displays.
+
+**Why:** The V2 filter engine only ran predicates for declared/displayed fields, so a client filter on an undisplayed field was silently ignored.
+
+**Impact:** Client filters on undisplayed fields now take effect. An undeclared field with an **empty** selection is not synthesized, and an already-declared field is never duplicated even when it also has an active selection.
+
+---
+
+### 7. `system-filters-operator` (AND/OR) Applied to the Sidebar Filter Engine
+
+**What:** The cross-field AND/OR operator (`system-filters-operator`) is now applied directly to the sidebar's filter engine. A pre-init `'or'` set before the sidebar subscribed is picked up, and subsequent operator changes update the engine (the `BehaviorSubject`'s initial `'and'` replay is skipped so it does not clobber a `filter-operator` input applied just before subscription).
+
+**Why:** V2 previously only re-ran the pipeline on operator changes **when client filters were active**, and did not otherwise apply the operator to the engine — so the cross-field AND/OR selection could be ignored.
+
+**Impact:** The cross-field operator now consistently governs how different filter fields are combined (within-field remains OR), including when set before the sidebar initializes.
+
+---
+
+### 8. Sidebar List No Longer Scrolls Horizontally (V1 Parity)
+
+**What:** The Comment Sidebar V2 virtual-scroll list now clips wide rows instead of scrolling sideways: `overflow-x: hidden` on the viewport and its content, and the CDK-generated content wrapper is capped to `max-width: 100%`. The group-header chevron container is also set to `display: flex`.
+
+**Why:** Without capping the wrapper, the CDK virtual-scroll content grew to its widest child, forcing horizontal overflow — V1 clips wide rows.
+
+**Impact:** Wide rows are clipped to the sidebar width (no sideways scrollbar), matching V1's layout.
+
+---

--- a/.claude/release-notes/runs/v6.0.0-beta.4/.complete
+++ b/.claude/release-notes/runs/v6.0.0-beta.4/.complete
@@ -1,0 +1,3 @@
+completed_at=2026-07-02T17:30:02Z
+pr_number=276
+pr_url=https://github.com/velt-js/docs/pull/276

--- a/.claude/release-notes/runs/v6.0.0-beta.4/01-agent-1.done
+++ b/.claude/release-notes/runs/v6.0.0-beta.4/01-agent-1.done
@@ -1,0 +1,3 @@
+stage=01-agent-1
+agent=mdx-release-notes-generator
+completed_at=2026-07-02T17:22:57Z

--- a/.claude/release-notes/runs/v6.0.0-beta.4/01-agent-1.log
+++ b/.claude/release-notes/runs/v6.0.0-beta.4/01-agent-1.log
@@ -1,0 +1,25 @@
+[run-release-note-agent] stage=01-agent-1 agent=mdx-release-notes-generator model=claude-opus-4-8 max-turns=100
+Agent-1 work complete for **v6.0.0-beta.4** (route class: core-SDK).
+
+## Summary
+
+**Created** `release-notes/version-6/sdk-changelog.mdx** — the version-6 directory did not exist yet, so I created it, modeling the frontmatter, `### Libraries` header, and `<Update>` structure on `version-5/sdk-changelog.mdx`.
+
+**Registered** the new `Version 6.0.0` group in `docs.json` navigation, placed above `Version 5.0.0` (validated the file still parses as JSON).
+
+### Content decisions
+- The release contains **only Improvements (3) and Bug Fixes (8)** — no New Features section was emitted since there's nothing to place there.
+- **11 source items → 11 bullets** (strict 1:1, no merging), all tagged `[**Comments**]` given the Comment Sidebar V2 focus.
+- A one-line summary sits at the top of the `<Update>` block; each bullet is ≤2 sentences.
+- **No breaking changes** in the note → no `upgrade-guide.mdx` edits, and no `### Breaking Changes` section or `<Warning>` block in the changelog (per rules).
+- Links verified against existing patterns:
+  - `/async-collaboration/comments-sidebar/v2/setup` and `.../customize-behavior`
+  - `/api-reference/sdk/api/api-methods#setcommentsidebarfilters` (confirmed the anchor exists)
+  - `setSidebarButtonCountType` is **not** documented in `api-methods.mdx`, so I referenced it inline as code rather than inventing a link.
+- Omitted the long inline code examples from the source note per the changelog brevity rules; linked to docs instead.
+
+### Notes
+- Per the automated-run rules, I did **not** commit, push, create a PR, or trigger Agent-2 — the outer script handles sequencing.
+- The optional durable run-note could not be written: both `.claude/release-notes/runs/...` and `.claude/logs` are write-protected in this environment (permission denied). The required deliverables (changelog + nav) are in place.
+
+Downstream (Agent-2) should look at: `comments-sidebar/v2/setup` & `customize-behavior`, and `api-methods` entries for `setCommentSidebarFilters` / `setSidebarButtonCountType`.

--- a/.claude/release-notes/runs/v6.0.0-beta.4/02-agent-2.done
+++ b/.claude/release-notes/runs/v6.0.0-beta.4/02-agent-2.done
@@ -1,0 +1,3 @@
+stage=02-agent-2
+agent=release-planning-agent
+completed_at=2026-07-02T17:24:27Z

--- a/.claude/release-notes/runs/v6.0.0-beta.4/02-agent-2.log
+++ b/.claude/release-notes/runs/v6.0.0-beta.4/02-agent-2.log
@@ -1,0 +1,26 @@
+[run-release-note-agent] stage=02-agent-2 agent=release-planning-agent model=claude-opus-4-8 max-turns=100
+All programmatic writes into `.claude/` are permission-gated in this environment — the same wall Agent-1 documented for its optional run-note. I cannot persist the planning file to disk. Delivering the complete analysis here so the outer script and Agent-3 have it.
+
+## Agent-2 Planning — v6.0.0-beta.4 (route: core-SDK)
+
+**Analysis result: NO downstream documentation updates required.** Every one of the 11 source items is a behavior/parity fix to the existing, already-documented Comment Sidebar V2. None of the flag criteria are met:
+
+| Criterion | Present? | Notes |
+|---|---|---|
+| New types/interfaces/enums | No | `CommentSidebarFilters` shape unchanged |
+| New/changed API signatures | No | `setCommentSidebarFilters(...)` and `setSidebarButtonCountType(...)` are behavior-only fixes; signatures unchanged |
+| New feature lacking docs | No | V2 sidebar already at `async-collaboration/comments-sidebar/v2/{setup,customize-behavior}.mdx` |
+| Breaking changes | No | Agent-1 confirmed none; no `version-6/upgrade-guide.mdx` edit |
+| New wireframes | No | — |
+| New primitives / props | No | — |
+
+**Per-area verdict:**
+- **Data Models** (`data-models.mdx`): N/A — none.
+- **API Methods** (`api-methods.mdx`): N/A — `setCommentSidebarFilters()` already documented (api-methods.mdx:1923), signature unchanged.
+- **Documentation**: N/A. One *optional/verify-only* note: `setSidebarButtonCountType('filter')` is a pre-existing public method absent from `api-methods.mdx` — **out of scope** for this release (not new here); flag for a future backfill, do not add now.
+- **UI Wireframes / Primitives**: N/A.
+- **Upgrade Guide**: N/A — no breaking changes.
+
+**Handoff to Agent-3/4/5:** No applicable work. Agent-6/7 should only confirm terminology consistency ("Comment Sidebar V2", `setCommentSidebarFilters`) in the new changelog — low effort.
+
+**Write limitation:** Target `.claude/logs/agent-2-planning-v6.0.0-beta.4.md` (and the run-dir fallback) are write-protected in this sandbox; every Write/Bash attempt was denied as a sensitive file. Full plan is captured above for the outer script to persist. Exiting successfully.

--- a/.claude/release-notes/runs/v6.0.0-beta.4/03-agent-3.done
+++ b/.claude/release-notes/runs/v6.0.0-beta.4/03-agent-3.done
@@ -1,0 +1,3 @@
+stage=03-agent-3
+agent=models-and-methods-updater
+completed_at=2026-07-02T17:25:34Z

--- a/.claude/release-notes/runs/v6.0.0-beta.4/03-agent-3.log
+++ b/.claude/release-notes/runs/v6.0.0-beta.4/03-agent-3.log
@@ -1,0 +1,23 @@
+[run-release-note-agent] stage=03-agent-3 agent=models-and-methods-updater model=claude-opus-4-8 max-turns=100
+Both write paths are permission-gated, consistent with what Agent-1 and Agent-2 hit. Delivering the result inline for the outer script to persist.
+
+## Agent-3 (models-and-methods-updater) — Result: NO-OP ✅
+
+**Version:** v6.0.0-beta.4 · **Route:** core-SDK · **Backend-only:** false
+
+**No changes made** to `api-reference/sdk/models/data-models.mdx` or `api-reference/sdk/api/api-methods.mdx`. This release contains no new or changed public types, interfaces, enums, hooks, or API signatures — all 11 source items are behavior/parity fixes to the already-documented **Comment Sidebar V2**.
+
+### Verification performed against live docs
+
+| Item | Finding | Action |
+|------|---------|--------|
+| `setCommentSidebarFilters()` | Already documented at `api-methods.mdx:1923`; params link to `CommentSidebarFilters`. Signature explicitly unchanged this release (behavior fix only, per input note). | None — correct as-is |
+| `CommentSidebarFilters` type | Already exists at `data-models.mdx:3406`; shape unchanged. | None — correct as-is |
+| `setSidebarButtonCountType()` | Pre-existing public method, **not** introduced in this release. Absent from `api-methods.mdx`, but out of scope for a behavior-fix-only release. | Deliberately NOT added — flag for future standalone backfill (per Agent-2) |
+
+### Notes
+- Agent-2's planning verdict ("NO downstream documentation updates required") independently confirmed against the actual reference files.
+- No commit/push/PR/branch created; no next agent dispatched — outer script handles sequencing.
+- The durable no-op note (`03-agent-3-noop.md`) could not be persisted: `.claude/` writes are permission-gated in this sandbox (same wall Agent-1 and Agent-2 reported). Full result captured above.
+
+**Handoff to Agent-4:** Technical reference docs (`data-models.mdx`, `api-methods.mdx`) remain unchanged and are the source of truth for Agent-5 alignment. Exiting successfully.

--- a/.claude/release-notes/runs/v6.0.0-beta.4/04-agent-4.done
+++ b/.claude/release-notes/runs/v6.0.0-beta.4/04-agent-4.done
@@ -1,0 +1,3 @@
+stage=04-agent-4
+agent=ui-customization-updater
+completed_at=2026-07-02T17:26:51Z

--- a/.claude/release-notes/runs/v6.0.0-beta.4/04-agent-4.log
+++ b/.claude/release-notes/runs/v6.0.0-beta.4/04-agent-4.log
@@ -1,0 +1,37 @@
+[run-release-note-agent] stage=04-agent-4 agent=ui-customization-updater model=claude-opus-4-8 max-turns=100
+The write into `.claude/` is permission-gated in this sandbox — the same wall Agents 1–3 all reported. I'll deliver the result inline for the outer script to persist, consistent with the prior agents.
+
+## Agent-4 (ui-customization-updater) — Result: NO-OP ✅
+
+**Version:** v6.0.0-beta.4 · **Route:** core-SDK · **Backend-only:** false
+
+**No wireframe or UI-customization changes made.** This release is entirely behavior/parity/CSS fixes to the already-documented **Comment Sidebar V2**. It introduces no new wireframe elements and no changes to the wireframe element hierarchy, so nothing under `ui-customization/` requires an edit and `docs.json` navigation is unchanged.
+
+### Scope check against Agent-4 trigger criteria
+
+| Criterion | Present? | Notes |
+|---|---|---|
+| New wireframes | No | — |
+| Changes to existing wireframe elements / hierarchy | No | All 11 items adjust runtime behavior, not structure |
+| New UI components needing code examples | No | No new public API methods |
+| New primitives (delegate to Agent-5) | No | Nothing to hand off |
+
+### Verification performed against live docs
+
+The Comment Sidebar V2 wireframe page already exists at `ui-customization/features/async/comments/comment-sidebar/comment-sidebar-v2-wireframes.mdx` and already documents the full filter wireframe hierarchy (`FilterContainer`, `GroupBy`, `SectionList`, `Section`, `FilterButton`, etc.). Every release item acts on **existing** components:
+
+- **Improvement 1** (group expand/collapse defaults + `sessionStorage` persistence) — default-state behavior; no element change.
+- **Improvement 2** (default Status = Open + In Progress) — seeded selection behavior on the existing Status section.
+- **Improvement 3** (`setCommentSidebarFilters` → clearable selected filters + stable facet counts) — API behavior; signature unchanged (Agent-3 confirmed documented at `api-methods.mdx:1923`).
+- **Bug Fix 1** (name-only location scoping), **2** (dup people keyed by `userId`), **3** (`setSidebarButtonCountType('filter')` badge source — method pre-existing), **4** (clear/"All" reveals resolved), **6** (client filters for undisplayed fields), **7** (`system-filters-operator` AND/OR) — all filter-engine/behavior fixes.
+- **Bug Fix 5** (Priority "Not set" bucket) — a filter *option value* rendered by the existing Priority section, not a wireframe primitive.
+- **Bug Fix 8** (no horizontal scroll) — CSS (`overflow-x`, `max-width`) on existing containers; not a wireframe element change.
+
+### Handoffs
+
+- **Agent-5 (primitives):** No primitive components added or changed — nothing to document. Pass through to Agent-6.
+- **Agent-6/7:** Only confirm terminology consistency ("Comment Sidebar V2", `setCommentSidebarFilters`) in the new changelog.
+
+**Write limitation:** `04-agent-4-noop.md` could not be persisted — `.claude/` writes are permission-gated in this sandbox (same wall Agents 1–3 hit). Full result captured above.
+
+No commit/push/PR/branch created; no next agent dispatched — the outer script handles sequencing. Exiting successfully.

--- a/.claude/release-notes/runs/v6.0.0-beta.4/05-agent-5.done
+++ b/.claude/release-notes/runs/v6.0.0-beta.4/05-agent-5.done
@@ -1,0 +1,3 @@
+stage=05-agent-5
+agent=primitives-updater
+completed_at=2026-07-02T17:27:33Z

--- a/.claude/release-notes/runs/v6.0.0-beta.4/05-agent-5.log
+++ b/.claude/release-notes/runs/v6.0.0-beta.4/05-agent-5.log
@@ -1,0 +1,32 @@
+[run-release-note-agent] stage=05-agent-5 agent=primitives-updater model=claude-opus-4-8 max-turns=100
+The write into `.claude/` is permission-gated in this sandbox — the same wall Agents 1–4 all reported. Delivering the result inline for the outer script to persist, consistent with the prior agents.
+
+## Agent-5 (primitives-updater) — Result: NO-OP ✅
+
+**Version:** v6.0.0-beta.4 · **Route:** core-SDK · **Backend-only:** false
+
+**No primitive component documentation changes made.** This release is focused entirely on the already-documented **Comment Sidebar V2** and consists solely of grouping/filtering/counting behavior, parity, and CSS fixes. It introduces no new standalone primitive components and no new or changed props/attributes on existing primitives.
+
+### Scope check against Agent-5 trigger criteria
+
+| Criterion | Present? | Notes |
+|---|---|---|
+| New primitive components (`Velt*` flat-named) | No | Release note lists none; only existing filter/group behavior is touched |
+| New/changed props or attributes on primitives | No | `setCommentSidebarFilters(...)` / `setSidebarButtonCountType(...)` are behavior-only fixes; signatures unchanged |
+| New feature area needing a primitives page | No | Comment Sidebar V2 already documented |
+| Primitives handed off from Agent-4 | No | Agent-4 explicitly reported nothing to hand off |
+
+### Corroboration from upstream agents
+- **Agent-2 (planning):** "New primitives / props: No." — no downstream documentation updates required.
+- **Agent-4 (wireframes):** "No primitive components added or changed — nothing to document. Pass through to Agent-6."
+
+### Item-by-item confirmation (all behavior/parity/CSS, no primitives)
+- **Improvements 1–3:** group expand/collapse defaults + `sessionStorage`, default Status seed (Open + In Progress), `setCommentSidebarFilters` clearable selected filters + stable facet counts — runtime behavior only.
+- **Bug Fixes 1–8:** name-only location scoping, dedup people by `userId`, `setSidebarButtonCountType('filter')` badge source, clear/"All" reveals resolved, Priority "Not set" bucket, client filters for undisplayed fields, `system-filters-operator` AND/OR, no horizontal scroll (CSS) — all filter-engine/behavior/CSS fixes on existing components.
+
+### Handoff
+- **Agent-6/7:** Only confirm terminology consistency ("Comment Sidebar V2", `setCommentSidebarFilters`) in the new changelog. No primitives pages or `docs.json` navigation edits were needed.
+
+**Write limitation:** `05-agent-5-noop.md` could not be persisted — `.claude/` writes are permission-gated in this sandbox (same wall Agents 1–4 hit). Full result captured above.
+
+No commit/push/PR/branch created; no next agent dispatched — the outer script handles sequencing. Exiting successfully.

--- a/.claude/release-notes/runs/v6.0.0-beta.4/06-agent-6.done
+++ b/.claude/release-notes/runs/v6.0.0-beta.4/06-agent-6.done
@@ -1,0 +1,3 @@
+stage=06-agent-6
+agent=documentation-alignment-enforcer
+completed_at=2026-07-02T17:28:34Z

--- a/.claude/release-notes/runs/v6.0.0-beta.4/06-agent-6.log
+++ b/.claude/release-notes/runs/v6.0.0-beta.4/06-agent-6.log
@@ -1,0 +1,25 @@
+[run-release-note-agent] stage=06-agent-6 agent=documentation-alignment-enforcer model=claude-opus-4-8 max-turns=100
+The `.claude/` write is permission-gated in this sandbox — the same wall Agents 1–5 all hit. Delivering the result inline for the outer script to persist.
+
+## Agent-6 (documentation-alignment) — v6.0.0-beta.4
+
+**Route:** core-SDK · **Backend-only:** false · **Result:** Aligned — no edits required ✅
+
+Upstream Agents 2–5 all reported NO-OP: every one of the 11 items is a behavior/parity/CSS fix to the already-documented **Comment Sidebar V2**, introducing no new feature names, APIs, wireframes, or primitives. The only newly added content is Agent-1's changelog `release-notes/version-6/sdk-changelog.mdx`, so alignment = verify its terminology and links against existing docs.
+
+### Change map (terminology)
+No from→to mappings — this release renames nothing. Verified the changelog already matches established terms:
+- **Comment Sidebar V2** (title case) — matches existing usage in `async-collaboration/comments-sidebar/v2/*` (4 hits).
+- `<velt-comments-sidebar-v2>` element — matches the 110 existing references.
+- `[**Comments**]` bullet tag — matches `version-5/sdk-changelog.mdx` convention.
+
+### Cross-reference / link validation
+- `/async-collaboration/comments-sidebar/v2/setup` → `setup.mdx` exists ✓
+- `/async-collaboration/comments-sidebar/v2/customize-behavior` → `customize-behavior.mdx` exists ✓
+- `#setcommentsidebarfilters` → heading at `api-methods.mdx:1923` yields that anchor ✓
+- `setSidebarButtonCountType('filter')` — correctly rendered as inline code, **not** linked (undocumented in `api-methods.mdx`; inventing a link would be wrong). No TODO placeholder needed since it isn't presented as a link.
+
+### Result
+No alignment edits applied — the changelog is already consistent with repo terminology, tag conventions, and link patterns. Nothing to reconcile across `docs/`, `ui-customization/`, `api-reference/`, or examples.
+
+**Handoff to Agent-7:** Change map above is the source of truth; repo-wide search/replace has no terminology to migrate for this release. Per automated-run rules, no commit/push/PR/branch and no next-agent dispatch — the outer script handles sequencing. Exiting successfully.

--- a/.claude/release-notes/runs/v6.0.0-beta.4/07-agent-7.done
+++ b/.claude/release-notes/runs/v6.0.0-beta.4/07-agent-7.done
@@ -1,0 +1,3 @@
+stage=07-agent-7
+agent=qa-terminology-aligner
+completed_at=2026-07-02T17:30:01Z

--- a/.claude/release-notes/runs/v6.0.0-beta.4/07-agent-7.log
+++ b/.claude/release-notes/runs/v6.0.0-beta.4/07-agent-7.log
@@ -1,0 +1,36 @@
+[run-release-note-agent] stage=07-agent-7 agent=qa-terminology-aligner model=claude-opus-4-8 max-turns=100
+Both `.claude/` write paths are permission-gated in this sandbox — the same wall every prior agent (1–6) hit. The outer script persists these logs. Delivering the QA result inline, consistent with the prior agents.
+
+## Agent-7 (QA Terminology Aligner) — v6.0.0-beta.4
+
+**Route:** core-SDK · **Backend-only:** false · **Result:** QA passed — 0 issues, 0 fixes ✅
+
+### Issues Found: 0
+
+Upstream agents 2–6 all reported NO-OP; the only new content is Agent-1's changelog. I validated it against the live repo — it is accurate and consistent. No terminology drift, no broken links, no bad sections, no repo-wide search/replace warranted (nothing was renamed this release).
+
+### Validation performed
+
+**Changelog** `release-notes/version-6/sdk-changelog.mdx`
+- Section order correct: `### Improvements` → `### Bug Fixes`. No New Features section (none in note), no Breaking Changes section, no `<Warning>` — per rules.
+- 11 source items → 11 bullets (3 Improvements, 8 Bug Fixes), all `[**Comments**]`-tagged, each ≤2 sentences. Frontmatter / `### Libraries` / `<Update>` structure matches `version-5/sdk-changelog.mdx`.
+
+**Terminology** — "Comment Sidebar V2" (title case) and `<velt-comments-sidebar-v2>` match existing `comments-sidebar/v2/*` docs. No from→to migration.
+
+**Links / anchors** (prose only; code correctly not linked)
+- `#setcommentsidebarfilters` → resolves to heading `api-methods.mdx:1923` ✓
+- `/async-collaboration/comments-sidebar/v2/setup` + `.../customize-behavior` → both `.mdx` files exist ✓
+- `setSidebarButtonCountType('filter')` → inline code, deliberately **not** linked (undocumented in api-methods.mdx; a fabricated link would be wrong). Correct.
+
+**Navigation** `docs.json` — "Version 6.0.0" group placed above "Version 5.0.0"; single `sdk-changelog` page; no upgrade-guide (no breaking changes); file validates as JSON ✓
+
+**api-methods.mdx** — unchanged (Agent-3 NO-OP); `setCommentSidebarFilters()` entry pre-existing and correctly scoped. No format issues, no edits.
+
+### Summary
+- Files corrected: **0** · Critical issues: **0** · Terminology alignments: **0**
+- Repo-wide search/replace: not needed.
+
+### Handoff to Plugin Agent 1 / Agent-1 readiness
+Documentation is consistent and validated — ready for the next release note. No commit/push/PR/branch and no next-agent dispatch (outer script handles sequencing). Optional future backfill flagged by Agent-2/3 (out of scope here): document the pre-existing `setSidebarButtonCountType()` public method in `api-methods.mdx`.
+
+**Write limitation:** both `.claude/logs/agent-7-qa-v6.0.0-beta.4.md` and the run-dir fallback are permission-gated in this sandbox (same wall Agents 1–6 reported). Full QA result captured above for the outer script to persist. Exiting successfully.

--- a/.claude/release-notes/runs/v6.0.0-beta.4/pr-body.md
+++ b/.claude/release-notes/runs/v6.0.0-beta.4/pr-body.md
@@ -1,0 +1,18 @@
+## Summary
+
+Automated release-note docs pipeline for `release-notes/v6.0.0-beta.4.md`.
+
+- Route: `core-SDK`
+- Source note: https://github.com/snippyly/internal-release-notes/blob/70bc69a9fb2915455ac217a43af703fae34fda01/release-notes/v6.0.0-beta.4.md
+- Rerun URL: https://github.com/snippyly/internal-release-notes/blob/70bc69a9fb2915455ac217a43af703fae34fda01/release-notes/v6.0.0-beta.4.md
+- Status: In progress
+- Run: https://github.com/velt-js/docs/actions/runs/28608781269
+
+## Needs human follow-up
+
+- Review the generated docs changes before merging.
+- Confirm the conservative automation defaults were appropriate for this note.
+
+## Checkpoints
+
+Runtime checkpoints are saved under `.claude/release-notes/runs/v6.0.0-beta.4`.

--- a/.claude/release-notes/runs/v6.0.0-beta.4/pr-body.md
+++ b/.claude/release-notes/runs/v6.0.0-beta.4/pr-body.md
@@ -5,7 +5,7 @@ Automated release-note docs pipeline for `release-notes/v6.0.0-beta.4.md`.
 - Route: `core-SDK`
 - Source note: https://github.com/snippyly/internal-release-notes/blob/70bc69a9fb2915455ac217a43af703fae34fda01/release-notes/v6.0.0-beta.4.md
 - Rerun URL: https://github.com/snippyly/internal-release-notes/blob/70bc69a9fb2915455ac217a43af703fae34fda01/release-notes/v6.0.0-beta.4.md
-- Status: In progress
+- Status: Complete
 - Run: https://github.com/velt-js/docs/actions/runs/28608781269
 
 ## Needs human follow-up

--- a/.claude/release-notes/runs/v6.0.0-beta.4/public-note.env
+++ b/.claude/release-notes/runs/v6.0.0-beta.4/public-note.env
@@ -1,0 +1,1 @@
+trimmed_internal_section=true

--- a/.claude/release-notes/runs/v6.0.0-beta.4/route.json
+++ b/.claude/release-notes/runs/v6.0.0-beta.4/route.json
@@ -1,0 +1,11 @@
+{
+  "class": "core-SDK",
+  "version": "v6.0.0-beta.4",
+  "stem": "v6.0.0-beta.4",
+  "safe_stem": "v6.0.0-beta.4",
+  "branch": "v6.0.0-beta.4",
+  "title": "v6.0.0-beta.4",
+  "changelog": "release-notes/version-6/sdk-changelog.mdx",
+  "major": "6",
+  "triage_reason": ""
+}

--- a/.claude/release-notes/runs/v6.0.0-beta.4/run.env
+++ b/.claude/release-notes/runs/v6.0.0-beta.4/run.env
@@ -1,0 +1,13 @@
+NOTE_REPO=snippyly/internal-release-notes
+SOURCE_REPO=snippyly/internal-release-notes
+NOTE_PATH=release-notes/v6.0.0-beta.4.md
+SOURCE_SHA=70bc69a9fb2915455ac217a43af703fae34fda01
+CHANGE_TYPE=added
+PIPELINE_MODE=resume
+RUN_URL=https://github.com/velt-js/docs/actions/runs/28608781269
+RN_CLASS=core-SDK
+RN_VERSION=v6.0.0-beta.4
+RN_BRANCH=v6.0.0-beta.4
+RN_TITLE=v6.0.0-beta.4
+RN_CHANGELOG=release-notes/version-6/sdk-changelog.mdx
+trimmed_internal_section=true

--- a/api-reference/sdk/api/api-methods.mdx
+++ b/api-reference/sdk/api/api-methods.mdx
@@ -1921,11 +1921,18 @@ Filter out comments from specified locations in the sidebar.
 
 ### System Filters, Sorting and Grouping
 #### setCommentSidebarFilters()
-Set filters for the comments sidebar programmatically.
+Set filters for the comments sidebar programmatically. The values are applied as selected (checked) filter options that merge per key and are cleared by Reset — pass a present-but-empty array to clear one field, or an empty object to clear all selections.
 - Params: `filters:` [`CommentSidebarFilters`](/api-reference/sdk/models/data-models#commentsidebarfilters)
 - Returns: `void`
 - React Hook: `n/a`
 - [Full Documentation →](/async-collaboration/comments-sidebar/v1/customize-behavior#setcommentsidebarfilters)
+
+#### setSidebarButtonCountType()
+Change what the sidebar button count badge reflects: `'default'` counts comments in open and in-progress states; `'filter'` counts the sidebar's filtered list.
+- Params: `type: string`
+- Returns: `void`
+- React Hook: `n/a`
+- [Full Documentation →](/async-collaboration/comments-sidebar/v2/customize-behavior#sidebarbuttoncounttype)
 
 
 

--- a/api-reference/sdk/api/api-methods.mdx
+++ b/api-reference/sdk/api/api-methods.mdx
@@ -1921,11 +1921,18 @@ Filter out comments from specified locations in the sidebar.
 
 ### System Filters, Sorting and Grouping
 #### setCommentSidebarFilters()
-Set filters for the comments sidebar programmatically. The values are applied as selected (checked) filter options that merge per key and are cleared by Reset — pass a present-but-empty array to clear one field, or an empty object to clear all selections.
+Set filters for the comments sidebar programmatically. Included keys replace their selected values while omitted keys are preserved. The values render as checked options and are cleared by Reset — pass a present-but-empty array to clear one field, or an empty object to clear all selections.
 - Params: `filters:` [`CommentSidebarFilters`](/api-reference/sdk/models/data-models#commentsidebarfilters)
 - Returns: `void`
 - React Hook: `n/a`
-- [Full Documentation →](/async-collaboration/comments-sidebar/v1/customize-behavior#setcommentsidebarfilters)
+- [Full Documentation →](/async-collaboration/comments-sidebar/v2/customize-behavior#setcommentsidebarfilters)
+
+#### setSystemFiltersOperator()
+Set how selections from different sidebar filter fields are combined. Values within one field always use OR.
+- Params: `operator: 'and' | 'or'`
+- Returns: `void`
+- React Hook: `n/a`
+- [Full Documentation →](/async-collaboration/comments-sidebar/v2/customize-behavior#systemfiltersoperator)
 
 #### setSidebarButtonCountType()
 Change what the sidebar button count badge reflects: `'default'` counts comments in open and in-progress states; `'filter'` counts the sidebar's filtered list.
@@ -3754,8 +3761,8 @@ Clear custom page info and revert to the SDK's automatic browser-derived page in
 Set the current location context. Used to define specific areas within a document.
 - Params: `location: Location, isAdditional?: boolean`
   - `location`: Location object with:
-    - `id`: Required unique identifier
-    - `locationName?`: Optional display name for UI components
+    - `id?`: Unique string or numeric identifier. Optional when `locationName` is provided.
+    - `locationName?`: Non-empty display name that identifies the location when `id` is omitted.
     - `version?`: Optional version object with:
       - `id`: Version identifier
       - `name`: Version display name

--- a/api-reference/sdk/api/react-hooks.mdx
+++ b/api-reference/sdk/api/react-hooks.mdx
@@ -640,8 +640,8 @@ Hook to clear custom page info and revert to the SDK's automatic browser-derived
 Hook to set the current location context. Used to define specific areas within a document.
 - Params:
   - `location`: Location object with:
-    - `id`: Required unique identifier
-    - `locationName?`: Optional display name for UI components
+    - `id?`: Unique string or numeric identifier. Optional when `locationName` is provided.
+    - `locationName?`: Non-empty display name that identifies the location when `id` is omitted.
     - `version?`: Optional version object with:
       - `id`: Version identifier
       - `name`: Version display name

--- a/api-reference/sdk/models/data-models.mdx
+++ b/api-reference/sdk/models/data-models.mdx
@@ -3407,19 +3407,22 @@ Registers a custom filterable field in the Comment Sidebar V2 pipeline by supply
 
 ---
 
-| Property   | Type                 | Required | Description                                                                              |
-| ---------- | -------------------- | -------- | ---------------------------------------------------------------------------------------- |
-| `location` | `{id: string}[]`     | No       | Filter by location Ids                                                                   |
-| `document` | `{id: string}[]`     | No       | Filter by document Ids                                                                   |
-| `people`   | `{userId: string}[]` | No       | Filter by author of comment annotation                                                   |
-| `tagged`   | `{userId: string}[]` | No       | Filter by users who were tagged/mentioned in the comment                                 |
-| `assigned` | `{userId: string}[]` | No       | Filter by users who were assigned to the comment annotation                              |
-| `involved` | `{userId: string}[]` | No       | Filter by users who are involved in the comment annotation (author, mentioned, assigned) |
-| `priority`    | `string[]`              | No       | Filter by priority ids                                                                   |
-| `status`      | `string[]`              | No       | Filter by status ids                                                                     |
-| `category`    | `string[]`              | No       | Filter by category ids                                                                   |
-| `version`     | `{id: string}[]`        | No       | Filter by version Ids                                                                    |
-| `accessModes` | [`CommentAccessMode`](#commentaccessmode)`[]` | No | Filter by access mode. Recognizes both legacy `iam.accessMode` and `visibilityConfig` (`restricted`, `organizationPrivate` → `'private'`; `public` → `'public'`). |
+For location and user filters, provide at least one documented identity field in each object.
+
+| Property       | Type                                                   | Required | Description                                                                              |
+| -------------- | ------------------------------------------------------ | -------- | ---------------------------------------------------------------------------------------- |
+| `location`     | `{ id?: string \| number; locationName?: string }[]`    | No       | Filter by location identity. `id` takes precedence; a non-empty `locationName` is used when `id` is absent. |
+| `document`     | `{ id: string }[]`                                     | No       | Filter by document ids                                                                   |
+| `people`       | `{ userId?: string; email?: string }[]`                 | No       | Filter by comment author. `email` is used when `userId` is absent.                        |
+| `tagged`       | `{ userId?: string; email?: string }[]`                 | No       | Filter by tagged or mentioned users. `email` is used when `userId` is absent.             |
+| `assigned`     | `{ userId?: string; email?: string }[]`                 | No       | Filter by assigned users. `email` is used when `userId` is absent.                        |
+| `involved`     | `{ userId?: string; email?: string }[]`                 | No       | Filter by involved users (author, mentioned, or assigned). `email` is used when `userId` is absent. |
+| `priority`     | `string[]`                                             | No       | Filter by priority ids                                                                   |
+| `status`       | `string[]`                                             | No       | Filter by status ids                                                                     |
+| `category`     | `string[]`                                             | No       | Filter by category ids                                                                   |
+| `version`      | `{ id: string }[]`                                     | No       | Filter by version ids                                                                    |
+| `accessModes`  | [`CommentAccessMode`](#commentaccessmode)`[]`           | No       | Filter by access mode. Recognizes both legacy `iam.accessMode` and `visibilityConfig` (`restricted`, `organizationPrivate` → `'private'`; `public` → `'public'`). |
+| `[key: string]`| `string[] \| { id?: string; name?: string }[] \| undefined` | No    | Custom field selections represented by string values or objects containing `id` and `name`. |
 
 #### CommentAccessMode
 
@@ -3440,7 +3443,7 @@ Registers a custom filterable field in the Comment Sidebar V2 pipeline by supply
 | ------------- | --------------------- | -------- | ----------------------------------------------- |
 | `groupId`     | `string`              | No       | ID of the group. Defaults to 'others'           |
 | `groupName`   | `string`              | No       | Name of the group. Defaults to 'Others'         |
-| `isExpanded`  | `boolean`             | No       | Whether the group is expanded. Defaults to true |
+| `isExpanded`  | `boolean`             | No       | Whether the group is expanded. In V2, an omitted value is resolved from user overrides and the current grouping default. |
 | `annotations` | `CommentAnnotation[]` | Yes      | List of CommentAnnotations in the group         |
 
 #### Options
@@ -3669,7 +3672,7 @@ Props accepted by the `VeltCommentDialog` component. The React TypeScript interf
 | `fullScreen`                        | `boolean`                 | No       | Adds a fullscreen toggle button to the header. Default `false`. |
 | `fullExpanded`                      | `boolean`                 | No       | Render the sidebar fully expanded. Default `false`.           |
 | `shadowDom`                         | `boolean`                 | No       | Render the sidebar body inside a shadow root for style isolation. Input default `false`; effective default on (V1 parity) unless disabled via `shadow-dom="false"` / `disableSidebarShadowDOM()`. |
-| `filters`                           | `string \| FilterField[] \| object` | No | Main Filter panel fields. An object of active selections routes to the V1 `setCommentSidebarFilters` path. Default `[]`. |
+| `filters`                           | `string \| FilterField[] \| CommentSidebarFilters` | No | Main Filter panel fields or active selected values. Included selection keys replace their values; omitted keys are preserved. Default `[]`. |
 | `miniFilters`                       | `string \| FilterField[]` | No       | Single header funnel dropdown (one section per field). Default `[]`. |
 | `minimalFilters`                    | `string \| SidebarMinimalFilterConfig[]` | No | Multiple configurable header dropdowns (`filter`/`sort`/`quick`/`actions`). Default `[]`. |
 | `filterOperator`                    | `'and' \| 'or'`           | No       | How selections across different fields combine. Default `'and'`. |
@@ -3677,7 +3680,7 @@ Props accepted by the `VeltCommentDialog` component. The React TypeScript interf
 | `filterOptionLayout`                | `'dropdown' \| 'checkbox'`| No       | Option control rendering. Default `'dropdown'`.               |
 | `filterCount`                       | `boolean`                 | No       | Show per-option facet counts. Default `true`.                 |
 | `filterGhostCommentsInSidebar`      | `boolean`                 | No       | Include ghost comments in the list. Default `false`.          |
-| `systemFiltersOperator`             | `'and' \| 'or'`           | No       | Operator applied to system filters. Unset by default.         |
+| `systemFiltersOperator`             | `'and' \| 'or'`           | No       | Operator applied across different filter fields. Values within one field use OR. Effective default `'and'`. |
 | `sortBy`                            | [`SortBy`](#sortby)       | No       | Default sort field (sets the default sort, not a UI dropdown). Unset by default. |
 | `sortOrder`                         | [`SortOrder`](#sortorder) | No       | Default sort order. Unset by default.                         |
 | `sortData`                          | `string`                  | No       | Custom-field sort path. Unset by default.                     |
@@ -5511,8 +5514,8 @@ Each resource represents something the user can access (organization, folder, or
 
 | Property        | Type      | Required | Description                                     |
 | --------------- | --------- | -------- | ----------------------------------------------- |
-| `id`            | `string`  | No       | Unique identifier for the location.             |
-| `locationName`  | `string`  | No       | Name of the location.                           |
+| `id`            | `string \| number` | No | Unique identifier for the location. An id of `0` is valid and takes precedence over `locationName`. |
+| `locationName`  | `string`  | No       | Name of the location. A non-empty name identifies the location when `id` is omitted. |
 | `version`       | `Version` | No       | Version information provided by the user.       |
 | `[key: string]` | `any`     | No       | Additional dynamic properties for the location. |
 

--- a/async-collaboration/comments-sidebar/v1/customize-behavior.mdx
+++ b/async-collaboration/comments-sidebar/v1/customize-behavior.mdx
@@ -1187,11 +1187,12 @@ Options: `createdAt` or `lastUpdated`
 
 
 #### setCommentSidebarFilters
-- Programmatically set the system filters on the sidebar.
+- Programmatically apply values as selected filters in the sidebar. Included keys replace their selected values while omitted keys are preserved; pass an empty array to clear one field or `{}` to clear all fields.
+- The selected values appear in the filter UI and are cleared by **Reset**.
 - Use `accessModes` to filter by privacy. Accepts `'public'` and/or `'private'`. Works with both the legacy `iam.accessMode` field and the new `visibilityConfig` field — `restricted` and `organizationPrivate` map to `'private'`; `public` or unset maps to `'public'`. See [`CommentAccessMode`](/api-reference/sdk/models/data-models#commentaccessmode).
 
 <Note>
-  If you build a custom filter dropdown inside `<velt-comments-sidebar-wireframe>`, drive `accessModes` through the same `setCommentSidebarFilters()` API (or your own state binding that calls it). The filter is resolved server-side by the sidebar pipeline, so your custom UI only needs to write the array.
+  If you build a custom filter dropdown inside `<velt-comments-sidebar-wireframe>`, drive `accessModes` through the same `setCommentSidebarFilters()` API or bind your state to a call that writes the selected values.
 </Note>
 
 <Tabs>

--- a/async-collaboration/comments-sidebar/v2/customize-behavior.mdx
+++ b/async-collaboration/comments-sidebar/v2/customize-behavior.mdx
@@ -15,7 +15,7 @@ There are three filter surfaces, each driven by its own input:
 #### filters
 - Define the Main Filter panel sections.
 - Pass an array of [`FilterField`](/api-reference/sdk/models/data-models#filterfield) to define sections. Built-in fields are referenced by `field` id; custom fields use `valuePath`.
-- When passed an object keyed by field (e.g. `{ status: ['open'] }`) instead of `FilterField[]`, it is treated as a set of active filter selections and applied directly.
+- When passed an object keyed by field (e.g. `{ status: ['open'] }`) instead of `FilterField[]`, it is treated as a set of active filter selections: the values are applied as selected (checked) options in the filter panel, merge per key with the existing selection, and are cleared by **Reset**. A present-but-empty array clears just that field; an empty object `{}` clears all selections.
 
 Default: `[]`
 
@@ -46,7 +46,7 @@ const filters = [
 </Tab>
 </Tabs>
 
-**Active-selections object form** — pass an object keyed by field instead of a `FilterField[]` to apply active filter selections directly:
+**Active-selections object form** — pass an object keyed by field instead of a `FilterField[]` to apply active filter selections. The values render as checked options in the filter panel and are cleared by **Reset**:
 
 <Tabs>
 <Tab title="React / Next.js">
@@ -336,7 +336,8 @@ Default: `true`
 </Tabs>
 
 #### systemFiltersOperator
-- Specify whether system filters are combined with an `and` or `or` operator.
+- Specify whether different filter fields are combined with an `and` or `or` operator in the sidebar filter engine. Values within a single field always match with OR.
+- Applies to client filters set via [`setCommentSidebarFilters()`](/api-reference/sdk/api/api-methods#setcommentsidebarfilters) as well, including a value set before the sidebar initializes.
 
 Default: `and`
 

--- a/async-collaboration/comments-sidebar/v2/customize-behavior.mdx
+++ b/async-collaboration/comments-sidebar/v2/customize-behavior.mdx
@@ -15,7 +15,7 @@ There are three filter surfaces, each driven by its own input:
 #### filters
 - Define the Main Filter panel sections.
 - Pass an array of [`FilterField`](/api-reference/sdk/models/data-models#filterfield) to define sections. Built-in fields are referenced by `field` id; custom fields use `valuePath`.
-- When passed an object keyed by field (e.g. `{ status: ['open'] }`) instead of `FilterField[]`, it is treated as a set of active filter selections: the values are applied as selected (checked) options in the filter panel, merge per key with the existing selection, and are cleared by **Reset**. A present-but-empty array clears just that field; an empty object `{}` clears all selections.
+- When passed a [`CommentSidebarFilters`](/api-reference/sdk/models/data-models#commentsidebarfilters) object (e.g. `{ status: ['OPEN'] }`) instead of `FilterField[]`, it is treated as active filter selections. Included keys replace their current selections, omitted keys are preserved, and **Reset** clears all selections. A present-but-empty array clears just that field; an empty object `{}` clears all selections.
 
 Default: `[]`
 
@@ -46,12 +46,17 @@ const filters = [
 </Tab>
 </Tabs>
 
-**Active-selections object form** — pass an object keyed by field instead of a `FilterField[]` to apply active filter selections. The values render as checked options in the filter panel and are cleared by **Reset**:
+**Active-selections object form** — pass a [`CommentSidebarFilters`](/api-reference/sdk/models/data-models#commentsidebarfilters) object instead of a `FilterField[]` to apply active filter selections. The values render as checked options in the filter panel and are cleared by **Reset**:
 
 <Tabs>
 <Tab title="React / Next.js">
 ```jsx
-<VeltCommentsSidebarV2 filters={{ status: ['open'], people: ['1.1', '2.3'] }} />
+<VeltCommentsSidebarV2
+  filters={{
+    status: ['OPEN'],
+    people: [{ userId: '1.1' }, { userId: '2.3' }],
+  }}
+/>
 ```
 </Tab>
 <Tab title="Other Frameworks">
@@ -59,11 +64,89 @@ const filters = [
 <velt-comments-sidebar-v2></velt-comments-sidebar-v2>
 <script>
   const sidebar = document.querySelector('velt-comments-sidebar-v2');
-  sidebar.filters = { status: ['open'], people: ['1.1', '2.3'] };
+  sidebar.filters = {
+    status: ['OPEN'],
+    people: [{ userId: '1.1' }, { userId: '2.3' }],
+  };
 </script>
 ```
 </Tab>
 </Tabs>
+
+#### default status selection
+
+On first load, the Status field selects the default **Open** status and every status whose type is **In Progress**. These selections are visible and clearable in the Main Filter panel.
+
+The sidebar does not seed these statuses after it restores filter state from `sessionStorage`, after you provide a status selection through [`setCommentSidebarFilters()`](#setcommentsidebarfilters), or after the user changes the Status selection. If the status catalog loads after the sidebar, an untouched default selection refreshes to the catalog's current default and ongoing status ids.
+
+Selecting **All**, clearing the Status field, or using **Reset** shows resolved and terminal comments. Clearing another field does not change whether resolved comments are shown, and Reset does not seed the default statuses again.
+
+#### priority "Not set" option
+
+The default Priority field includes a **Not set** option for comments without a priority. A custom [`FilterField`](/api-reference/sdk/models/data-models#filterfield) with `includeUnset: false` omits this option.
+
+#### setCommentSidebarFilters
+
+Use `setCommentSidebarFilters()` to apply client-provided values as selected options in the sidebar. Each call replaces selections for keys it includes and preserves omitted keys:
+
+- Pass an empty array to clear one field.
+- Pass an empty object (`{}`) to clear every selected field.
+- Use **Reset** in the Main Filter panel to clear client-provided selections.
+
+Facet counts remain absolute within the page-scoped annotation set instead of shrinking around the client-provided selections. The Main Filter badge includes these selections. A non-empty selection also filters when its field is not displayed in the panel; empty undeclared fields are ignored, and declared fields are not duplicated.
+
+Values are normalized as follows:
+
+- `location`: by `id`, falling back to `locationName`
+- `people`, `assigned`, `tagged`, and `involved`: by `userId`, falling back to `email`
+- `status`, `priority`, and `category`: by the provided values without normalization
+- `accessModes`: by comment visibility (`'public'` or `'private'`)
+- `version`: by `id`
+- Custom fields: string values or objects containing `id` and `name`
+
+<Tabs>
+<Tab title="React / Next.js">
+```tsx
+import { useVeltClient } from '@veltdev/react';
+
+const { client } = useVeltClient();
+const commentElement = client.getCommentElement();
+
+commentElement.setCommentSidebarFilters({
+  status: ['OPEN'],
+  involved: [{ userId: 'user-123' }],
+  location: [{ locationName: 'Home' }],
+});
+
+commentElement.setCommentSidebarFilters({ location: [] }); // Clear one field
+commentElement.setCommentSidebarFilters({}); // Clear all fields
+```
+</Tab>
+<Tab title="Other Frameworks">
+```js
+const commentElement = Velt.getCommentElement();
+
+commentElement.setCommentSidebarFilters({
+  status: ['OPEN'],
+  involved: [{ userId: 'user-123' }],
+  location: [{ locationName: 'Home' }],
+});
+
+commentElement.setCommentSidebarFilters({ location: [] }); // Clear one field
+commentElement.setCommentSidebarFilters({}); // Clear all fields
+```
+</Tab>
+</Tabs>
+
+#### location identity
+
+The sidebar identifies a location by its `id`, falling back to `locationName` when the id is `null`, `undefined`, or an empty string. An id of `0` remains valid, numeric annotation ids compare with equivalent string filter values, and `id` takes precedence when both fields are present.
+
+This identity is used consistently by grouping, location filter options and matching, page mode, and client filters. Comments without any location context appear in the **Others** group.
+
+#### people filter identity
+
+People, Involved, Assigned, and Tagged options are keyed by `userId` and use the person's name as the label, with an email fallback. Records containing only an email do not create filter options, preventing duplicate options when another record for the same person contains a `userId`.
 
 #### miniFilters
 - Render a single header funnel dropdown with one section per field.
@@ -263,6 +346,7 @@ Prefer configuring dropdowns through `minimalFilters` as shown above. If you nee
 #### filterOperator
 - Control how active selections across different filter sections combine.
 - Options: `and` or `or`
+- This directly configures the Comment Sidebar V2 filter engine. The shared `systemFiltersOperator` input and API update the same effective operator.
 
 Default: `and`
 
@@ -318,7 +402,7 @@ Default: `dropdown`
 </Tabs>
 
 #### filterCount
-- Show per-option facet counts. Disabling improves performance.
+- Show per-option facet counts. Counts remain absolute within the current page-scoped annotation set and do not shrink around selections supplied through `setCommentSidebarFilters()`. Disabling improves performance.
 
 Default: `true`
 
@@ -337,7 +421,8 @@ Default: `true`
 
 #### systemFiltersOperator
 - Specify whether different filter fields are combined with an `and` or `or` operator in the sidebar filter engine. Values within a single field always match with OR.
-- Applies to client filters set via [`setCommentSidebarFilters()`](/api-reference/sdk/api/api-methods#setcommentsidebarfilters) as well, including a value set before the sidebar initializes.
+- Applies to client filters set via [`setCommentSidebarFilters()`](#setcommentsidebarfilters) as well, including a value set before the sidebar initializes and changes made at runtime.
+- An explicit `filterOperator` set during initialization is preserved instead of being overwritten by the shared operator's initial default value.
 
 Default: `and`
 
@@ -356,6 +441,10 @@ commentElement.setSystemFiltersOperator('or');
 <Tab title="Other Frameworks">
 ```html
 <velt-comments-sidebar-v2 system-filters-operator="or"></velt-comments-sidebar-v2>
+```
+```js
+const commentElement = Velt.getCommentElement();
+commentElement.setSystemFiltersOperator('or');
 ```
 </Tab>
 </Tabs>
@@ -508,6 +597,10 @@ const filtered = commentElement.applyCommentSidebarClientFilters(annotations, fi
 
 #### groupConfig
 - Configure grouping in the sidebar. Grouping defaults to by-location when enabled.
+- For location grouping, the current and additional-location groups start expanded while other location groups start collapsed. For document grouping, the current document starts expanded while other documents start collapsed.
+- Status, priority, and custom-field groups start expanded.
+- Explicit user expansion takes precedence over explicit collapse, which takes precedence over the grouping default. Both overrides persist in `sessionStorage`.
+- A real location change resets the overrides so the new current group expands. The initial location emitted during a reload preserves restored overrides.
 
 <Tabs>
 <Tab title="React / Next.js">
@@ -633,6 +726,7 @@ Default: `false`
 
 #### pageMode
 - Adds a composer in the sidebar where users can add comments without attaching them to any specific element.
+- The list is scoped using the current [location identity](#location-identity), so a location with only `locationName` behaves the same as an id-based location.
 
 Default: `false`
 
@@ -1074,7 +1168,9 @@ Default: `Search comments`
 #### sidebarButtonCountType
 - Change what the sidebar button count reflects.
   - `default`: total count of comments in open and in-progress states.
-  - `filter`: count of filtered comments.
+  - `filter`: count of the sidebar's filtered comments, including `0` for an empty result. The count updates when comments are deleted.
+- When [`filterCommentsOnDom`](/async-collaboration/comments/customize-behavior#filtercommentsondom) is enabled, the same filtered list controls which pins appear on the page.
+- The current filtered result is preserved while the sidebar is loading. It is cleared when the sidebar is destroyed so a removed sidebar no longer gates the badge or on-page pins.
 
 <Tabs>
 <Tab title="React / Next.js">
@@ -1091,6 +1187,10 @@ commentElement.setSidebarButtonCountType('filter');
 <Tab title="Other Frameworks">
 ```html
 <velt-comments-sidebar-v2 sidebar-button-count-type="filter"></velt-comments-sidebar-v2>
+```
+```js
+const commentElement = Velt.getCommentElement();
+commentElement.setSidebarButtonCountType('filter');
 ```
 </Tab>
 </Tabs>
@@ -1116,6 +1216,7 @@ commentSidebarElement?.setAttribute('context', JSON.stringify({ jobId: 'job-page
 
 #### Virtual scrolling
 - The V2 list uses virtual scrolling. Tune it with `measuredSize` (estimated row size in px), `minBufferPx`, and `maxBufferPx`.
+- Rows wider than the viewport are clipped to the sidebar width instead of creating a horizontal scrollbar.
 
 Defaults: `measuredSize` = `220`, `minBufferPx` = `1000`, `maxBufferPx` = `2000`
 
@@ -1193,5 +1294,5 @@ commentElement.toggleCommentSidebar();
 </Tabs>
 
 <Note>
-For V2 wireframe and primitive customization, see [Comment Sidebar V2 Structure](/ui-customization/features/async/comments/comment-sidebar-structure-v2) and [Comment Sidebar V2 Primitives](/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-v2-primitives). The sidebar is shadow-DOM isolated by default.
+For V2 customization, see [Comment Sidebar V2 Wireframes](/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-v2-wireframes) and [Comment Sidebar V2 Primitives](/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-v2-primitives). The sidebar is shadow-DOM isolated by default.
 </Note>

--- a/async-collaboration/comments-sidebar/v2/setup.mdx
+++ b/async-collaboration/comments-sidebar/v2/setup.mdx
@@ -10,6 +10,7 @@ The V2 sidebar is a fully primitive-based implementation. Import `VeltCommentsSi
 ```jsx
 import {
   VeltProvider,
+  VeltComments,
   VeltCommentsSidebarV2,
   VeltSidebarButton,
   VeltCommentTool
@@ -41,4 +42,4 @@ export default function App() {
 
 For V2 props reference, see [`VeltCommentsSidebarV2Props`](/api-reference/sdk/models/data-models#veltcommentssidebarv2props).
 
-For V2 wireframe customization, see [Comment Sidebar V2 UI Customization](/ui-customization/features/async/comments/comment-sidebar-structure-v2).
+For V2 wireframe customization, see [Comment Sidebar V2 Wireframes](/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-v2-wireframes).

--- a/docs.json
+++ b/docs.json
@@ -1069,6 +1069,12 @@
             "group": "Release Notes",
             "pages": [
               {
+                "group": "Version 6.0.0",
+                "pages": [
+                  "release-notes/version-6/sdk-changelog"
+                ]
+              },
+              {
                 "group": "Version 5.0.0",
                 "pages": [
                   "release-notes/version-5/upgrade-guide",

--- a/key-concepts/overview.mdx
+++ b/key-concepts/overview.mdx
@@ -844,8 +844,8 @@ For instance:
 - Access controls cannot be set at the location level.
 - Locations automatically generate location groups in the sidebar and organizes the comments within the group.
 - The location object has these fields:
-  - `id` (required): A unique identifier for the location that can be used to reference it later
-  - `locationName` (recommended): A human-readable name displayed in Velt components like the `VeltCommentsSideBar`
+  - `id` (optional when `locationName` is set): A unique string or numeric identifier. An id of `0` is valid and takes precedence over `locationName`.
+  - `locationName` (optional when `id` is set): A non-empty, human-readable name displayed in Velt components like `VeltCommentsSidebar`. It also identifies the location when `id` is omitted.
   - You can add any number of custom fields to the location object.
 
 ### APIs

--- a/release-notes/version-6/sdk-changelog.mdx
+++ b/release-notes/version-6/sdk-changelog.mdx
@@ -1,0 +1,42 @@
+---
+title: "Velt SDK Changelog"
+rss: true
+description: Release Notes of changes added to the core Velt SDK
+---
+
+### Libraries
+- `@veltdev/react`
+- `@veltdev/client`
+- `@veltdev/sdk`
+
+<Update label="6.0.0-beta.4" description="July 02, 2026">
+
+This release brings the Comment Sidebar V2 (`<velt-comments-sidebar-v2>`) to parity with V1 across grouping, filtering, and counting. No new public API methods and no breaking changes.
+
+### Improvements
+
+- [**Comments**]: When grouped by **location** or **document**, the Comment Sidebar V2 list now expands only the current page's (or current document's) group by default and collapses the rest, matching V1. User expand and collapse actions are tracked independently and persisted to `sessionStorage`, so a group you open or close stays that way across reloads. [Learn more →](/async-collaboration/comments-sidebar/v2/setup)
+
+- [**Comments**]: The Status filter now starts with **Open** and every **In Progress** status pre-selected as visible, clearable options on first load, matching V1's `setDefaultStatuses`. The seed is skipped when `sessionStorage` state was restored, when a client filter was supplied, or once you touch the selection. [Learn more →](/async-collaboration/comments-sidebar/v2/customize-behavior)
+
+- [**Comments**]: [`setCommentSidebarFilters()`](/api-reference/sdk/api/api-methods#setcommentsidebarfilters) now maps client filters onto the sidebar's own selected-filter state, so they render as checked options, merge per key, and are cleared by **Reset**. Facet option counts stay absolute within the page-scoped universe instead of shrinking when client filters are applied. [Learn more →](/api-reference/sdk/api/api-methods#setcommentsidebarfilters)
+
+### Bug Fixes
+
+- [**Comments**]: Name-only locations (`setLocation({ locationName: 'Home' })`) now scope sidebar grouping, the location filter, and page mode. A single location-identity source of truth keys locations by `id`, falling back to `locationName` for id-less pages, and coerces numeric ids to strings.
+
+- [**Comments**]: People, Involved, Assigned, and Tagged filter options are now keyed strictly by `userId`, so a person referenced by both `userId` and email no longer appears as two options with diverging counts. Options are labeled `name || email`.
+
+- [**Comments**]: With `setSidebarButtonCountType('filter')`, the sidebar-button badge now counts the actual filtered list (including an empty list showing 0) instead of falling back to all annotations. The filter map is preserved during skeleton loading and reset when the sidebar is destroyed.
+
+- [**Comments**]: Selecting **"All"** on the Status field or hitting **Reset** now reveals resolved/terminal comments, matching V1. Clearing a non-status field leaves the resolved flag untouched, and Reset does not re-trigger the Open + In Progress seed.
+
+- [**Comments**]: The default Priority section now shows a **"Not set"** bucket for comments with no priority, matching V1. Fields configured with `includeUnset: false` still omit it.
+
+- [**Comments**]: Client filters pushed via [`setCommentSidebarFilters()`](/api-reference/sdk/api/api-methods#setcommentsidebarfilters) for a field not shown in the Main Filter panel (e.g. `version`) now filter the list by synthesizing a field descriptor for it. Empty selections are not synthesized and declared fields are never duplicated.
+
+- [**Comments**]: The cross-field `system-filters-operator` (AND/OR) is now applied directly to the sidebar filter engine, including a value set before the sidebar initializes. Within-field matching remains OR.
+
+- [**Comments**]: The Comment Sidebar V2 virtual-scroll list now clips wide rows instead of scrolling horizontally, matching V1's layout.
+
+</Update>

--- a/release-notes/version-6/sdk-changelog.mdx
+++ b/release-notes/version-6/sdk-changelog.mdx
@@ -11,19 +11,22 @@ description: Release Notes of changes added to the core Velt SDK
 
 <Update label="6.0.0-beta.4" description="July 02, 2026">
 
-This release brings the Comment Sidebar V2 (`<velt-comments-sidebar-v2>`) to parity with V1 across grouping, filtering, and counting. No new public API methods and no breaking changes.
+This release brings the Comment Sidebar V2 (`<velt-comments-sidebar-v2>`) to parity with V1 across grouping, filtering, and counting. No new public API methods or breaking changes are included, and the React SDK change is a version bump only.
 
 ### Improvements
 
-- [**Comments**]: When grouped by **location** or **document**, the Comment Sidebar V2 list now expands only the current page's (or current document's) group by default and collapses the rest, matching V1. User expand and collapse actions are tracked independently and persisted to `sessionStorage`, so a group you open or close stays that way across reloads. [Learn more →](/async-collaboration/comments-sidebar/v2/customize-behavior#groupconfig)
+- [**Comments**]: When grouped by **location**, the Comment Sidebar V2 list now expands the current and additional-location groups while other locations start collapsed; when grouped by **document**, only the current document starts expanded. Status, priority, and custom groupings still start fully expanded, while explicit expand and collapse choices persist across reloads and take precedence in that order over the default; a real location change resets them, while the initial location emitted during a reload preserves them. [Learn more →](/async-collaboration/comments-sidebar/v2/customize-behavior#groupconfig)
 
-- [**Comments**]: The Status filter now starts with **Open** and every **In Progress** status pre-selected as visible, clearable options on first load, matching V1's `setDefaultStatuses`. The seed is skipped when `sessionStorage` state was restored, when a client filter was supplied, or once you touch the selection. [Learn more →](/async-collaboration/comments-sidebar/v2/customize-behavior)
+- [**Comments**]: The Status filter now starts with **Open** and every **In Progress** status pre-selected as visible, clearable options on first load, matching V1's `setDefaultStatuses`. The seed is skipped when `sessionStorage` state was restored, when a client-provided status filter was supplied, or once you touch the selection; an untouched seed refreshes if the status catalog loads later. [Learn more →](/async-collaboration/comments-sidebar/v2/customize-behavior#default-status-selection)
 
-- [**Comments**]: [`setCommentSidebarFilters()`](/api-reference/sdk/api/api-methods#setcommentsidebarfilters) now maps client filters onto the sidebar's own selected-filter state, so they render as checked options, merge per key, and are cleared by **Reset**. Facet option counts stay absolute within the page-scoped universe instead of shrinking when client filters are applied. [Learn more →](/api-reference/sdk/api/api-methods#setcommentsidebarfilters)
+- [**Comments**]: [`setCommentSidebarFilters()`](/api-reference/sdk/api/api-methods#setcommentsidebarfilters) now maps client filters onto the sidebar's selected-filter state, so they render as checked options and are cleared by **Reset**. Each call replaces selections for keys it includes while preserving omitted keys; facet counts remain absolute within the page-scoped universe, and the Main Filter badge reflects the applied selections. [Learn more →](/async-collaboration/comments-sidebar/v2/customize-behavior#setcommentsidebarfilters)
 
 <Tabs>
 <Tab title="React / Next.js">
-```js
+```tsx
+import { useVeltClient } from '@veltdev/react';
+
+const { client } = useVeltClient();
 const commentElement = client.getCommentElement();
 
 // Applied as selected (checked) filter options; Reset clears them.
@@ -62,15 +65,18 @@ commentElement.setCommentSidebarFilters({});
 
 ### Bug Fixes
 
-- [**Comments**]: Name-only locations (`setLocation({ locationName: 'Home' })`) now scope sidebar grouping, the location filter, and page mode. A single location-identity source of truth keys locations by `id`, falling back to `locationName` for id-less pages, and coerces numeric ids to strings.
+- [**Comments**]: Name-only locations (`setLocation({ locationName: 'Home' })`) now scope sidebar grouping, filtering, page mode, and client filters. Location identity uses `id` when present (including `0`) and otherwise falls back to `locationName`; numeric ids compare consistently with string filter values, and comments without a location appear under **Others**.
 
-- [**Comments**]: People, Involved, Assigned, and Tagged filter options are now keyed strictly by `userId`, so a person referenced by both `userId` and email no longer appears as two options with diverging counts. Options are labeled `name || email`.
+- [**Comments**]: People, Involved, Assigned, and Tagged filter options are now keyed strictly by `userId`, so a person referenced by both `userId` and email no longer appears as two options with diverging counts. Options use the person's name with an email fallback; contacts that only have an email do not become filter options.
 
-- [**Comments**]: With `setSidebarButtonCountType('filter')`, the sidebar-button badge now counts the actual filtered list (including an empty list showing 0) instead of falling back to all annotations. The filter map is preserved during skeleton loading and reset when the sidebar is destroyed. [Learn more →](/async-collaboration/comments-sidebar/v2/customize-behavior#sidebarbuttoncounttype)
+- [**Comments**]: With `setSidebarButtonCountType('filter')`, the sidebar-button badge now counts the actual filtered list, including an empty list showing `0` and updates after deletion. The same filtered list gates on-page pins when `filterCommentsOnDom` is enabled; the current result is preserved while the sidebar loads and stops gating the badge and pins after the sidebar is removed. [Learn more →](/async-collaboration/comments-sidebar/v2/customize-behavior#sidebarbuttoncounttype)
 
 <Tabs>
 <Tab title="React / Next.js">
-```js
+```tsx
+import { useVeltClient } from '@veltdev/react';
+
+const { client } = useVeltClient();
 const commentElement = client.getCommentElement();
 commentElement.setSidebarButtonCountType('filter'); // badge now counts the filtered list
 ```
@@ -90,9 +96,9 @@ commentElement.setSidebarButtonCountType('filter'); // badge now counts the filt
 
 - [**Comments**]: The default Priority section now shows a **"Not set"** bucket for comments with no priority, matching V1. Fields configured with `includeUnset: false` still omit it.
 
-- [**Comments**]: Client filters pushed via [`setCommentSidebarFilters()`](/api-reference/sdk/api/api-methods#setcommentsidebarfilters) for a field not shown in the Main Filter panel (e.g. `version`) now filter the list by synthesizing a field descriptor for it. Empty selections are not synthesized and declared fields are never duplicated.
+- [**Comments**]: Client filters pushed via [`setCommentSidebarFilters()`](/api-reference/sdk/api/api-methods#setcommentsidebarfilters) for a field not shown in the Main Filter panel (for example, `version`) now filter the list. Empty selections are ignored, and a field already declared in the panel is not duplicated.
 
-- [**Comments**]: The cross-field `system-filters-operator` (AND/OR) is now applied directly to the sidebar filter engine, including a value set before the sidebar initializes. Within-field matching remains OR.
+- [**Comments**]: The cross-field `system-filters-operator` (AND/OR) is now applied directly to the sidebar filter engine, including a value set before initialization and changes made at runtime. Within-field matching remains OR.
 
 - [**Comments**]: The Comment Sidebar V2 virtual-scroll list now clips wide rows instead of scrolling horizontally, matching V1's layout.
 

--- a/release-notes/version-6/sdk-changelog.mdx
+++ b/release-notes/version-6/sdk-changelog.mdx
@@ -15,11 +15,50 @@ This release brings the Comment Sidebar V2 (`<velt-comments-sidebar-v2>`) to par
 
 ### Improvements
 
-- [**Comments**]: When grouped by **location** or **document**, the Comment Sidebar V2 list now expands only the current page's (or current document's) group by default and collapses the rest, matching V1. User expand and collapse actions are tracked independently and persisted to `sessionStorage`, so a group you open or close stays that way across reloads. [Learn more →](/async-collaboration/comments-sidebar/v2/setup)
+- [**Comments**]: When grouped by **location** or **document**, the Comment Sidebar V2 list now expands only the current page's (or current document's) group by default and collapses the rest, matching V1. User expand and collapse actions are tracked independently and persisted to `sessionStorage`, so a group you open or close stays that way across reloads. [Learn more →](/async-collaboration/comments-sidebar/v2/customize-behavior#groupconfig)
 
 - [**Comments**]: The Status filter now starts with **Open** and every **In Progress** status pre-selected as visible, clearable options on first load, matching V1's `setDefaultStatuses`. The seed is skipped when `sessionStorage` state was restored, when a client filter was supplied, or once you touch the selection. [Learn more →](/async-collaboration/comments-sidebar/v2/customize-behavior)
 
 - [**Comments**]: [`setCommentSidebarFilters()`](/api-reference/sdk/api/api-methods#setcommentsidebarfilters) now maps client filters onto the sidebar's own selected-filter state, so they render as checked options, merge per key, and are cleared by **Reset**. Facet option counts stay absolute within the page-scoped universe instead of shrinking when client filters are applied. [Learn more →](/api-reference/sdk/api/api-methods#setcommentsidebarfilters)
+
+<Tabs>
+<Tab title="React / Next.js">
+```js
+const commentElement = client.getCommentElement();
+
+// Applied as selected (checked) filter options; Reset clears them.
+commentElement.setCommentSidebarFilters({
+  status: ['OPEN'],
+  involved: [{ userId: 'user-123' }],
+  location: [{ id: 'locationA', locationName: 'Location A' }],
+});
+
+// A present-but-empty array clears just that field:
+commentElement.setCommentSidebarFilters({ location: [] });
+
+// An empty object clears ALL selections:
+commentElement.setCommentSidebarFilters({});
+```
+</Tab>
+<Tab title="Other Frameworks">
+```js
+const commentElement = Velt.getCommentElement();
+
+// Applied as selected (checked) filter options; Reset clears them.
+commentElement.setCommentSidebarFilters({
+  status: ['OPEN'],
+  involved: [{ userId: 'user-123' }],
+  location: [{ id: 'locationA', locationName: 'Location A' }],
+});
+
+// A present-but-empty array clears just that field:
+commentElement.setCommentSidebarFilters({ location: [] });
+
+// An empty object clears ALL selections:
+commentElement.setCommentSidebarFilters({});
+```
+</Tab>
+</Tabs>
 
 ### Bug Fixes
 
@@ -27,7 +66,25 @@ This release brings the Comment Sidebar V2 (`<velt-comments-sidebar-v2>`) to par
 
 - [**Comments**]: People, Involved, Assigned, and Tagged filter options are now keyed strictly by `userId`, so a person referenced by both `userId` and email no longer appears as two options with diverging counts. Options are labeled `name || email`.
 
-- [**Comments**]: With `setSidebarButtonCountType('filter')`, the sidebar-button badge now counts the actual filtered list (including an empty list showing 0) instead of falling back to all annotations. The filter map is preserved during skeleton loading and reset when the sidebar is destroyed.
+- [**Comments**]: With `setSidebarButtonCountType('filter')`, the sidebar-button badge now counts the actual filtered list (including an empty list showing 0) instead of falling back to all annotations. The filter map is preserved during skeleton loading and reset when the sidebar is destroyed. [Learn more →](/async-collaboration/comments-sidebar/v2/customize-behavior#sidebarbuttoncounttype)
+
+<Tabs>
+<Tab title="React / Next.js">
+```js
+const commentElement = client.getCommentElement();
+commentElement.setSidebarButtonCountType('filter'); // badge now counts the filtered list
+```
+</Tab>
+<Tab title="Other Frameworks">
+```js
+const commentElement = Velt.getCommentElement();
+commentElement.setSidebarButtonCountType('filter'); // badge now counts the filtered list
+```
+```html
+<velt-comments-sidebar-v2 sidebar-button-count-type="filter"></velt-comments-sidebar-v2>
+```
+</Tab>
+</Tabs>
 
 - [**Comments**]: Selecting **"All"** on the Status field or hitting **Reset** now reveals resolved/terminal comments, matching V1. Clearing a non-status field leaves the resolved flag untouched, and Reset does not re-trigger the Open + In Progress seed.
 

--- a/snippets/comments-methods-json.mdx
+++ b/snippets/comments-methods-json.mdx
@@ -673,9 +673,23 @@ export const commentsJSON = [
  },
  {
    "methodName": "setCommentSidebarFilters",
-   "description": "To apply filters on comment sidebar.",
+   "description": "Apply selected filters to the comment sidebar.",
    "signature": "setCommentSidebarFilters(filters: CommentSidebarFilters)",
    "parameters": "filters: CommentSidebarFilters",
+   "returnType": "void"
+ },
+ {
+   "methodName": "setSystemFiltersOperator",
+   "description": "Set how selections from different comment sidebar filter fields are combined.",
+   "signature": "setSystemFiltersOperator(operator: 'and' | 'or')",
+   "parameters": "operator: 'and' | 'or'",
+   "returnType": "void"
+ },
+ {
+   "methodName": "setSidebarButtonCountType",
+   "description": "Set whether the sidebar button counts default-status or filtered comments.",
+   "signature": "setSidebarButtonCountType(type: string)",
+   "parameters": "type: string",
    "returnType": "void"
  },
  {


### PR DESCRIPTION
## Summary

Automated release-note docs pipeline for `release-notes/v6.0.0-beta.4.md`.

- Route: `core-SDK`
- Source note: https://github.com/snippyly/internal-release-notes/blob/70bc69a9fb2915455ac217a43af703fae34fda01/release-notes/v6.0.0-beta.4.md
- Rerun URL: https://github.com/snippyly/internal-release-notes/blob/70bc69a9fb2915455ac217a43af703fae34fda01/release-notes/v6.0.0-beta.4.md
- Status: Complete
- Run: https://github.com/velt-js/docs/actions/runs/28608781269

## Needs human follow-up

- Review the generated docs changes before merging.
- Confirm the conservative automation defaults were appropriate for this note.

## Checkpoints

Runtime checkpoints are saved under `.claude/release-notes/runs/v6.0.0-beta.4`.
