### PR TITLE
v6.0.0-beta.9

### DIFF
--- a/.claude/release-notes/input-v6.0.0-beta.9.md
+++ b/.claude/release-notes/input-v6.0.0-beta.9.md
@@ -1,0 +1,181 @@
+# Velt SDK Release Notes - v6.0.0-beta.9
+Release Date: July 10, 2026
+
+## Summary
+| SDK | Files Changed | Insertions | Deletions |
+|-----|--------------|------------|-----------|
+| HTML/Vanilla (sdk) | 74 | +1297 | -134 |
+| React (sdk-react) | 3 | +4 | -4 |
+
+> This release is another round of **Comment Sidebar V2** (`<velt-comments-sidebar-v2>`) parity and contract fixes, driven by an audit of the sidebar test harness. It fixes open/close events, filtering behavior, cross-page navigation, and a few input attributes. There is **one new public event (`fullscreenClick`)** and **no breaking changes**. The React SDK change is a version bump only.
+
+## API Changes
+
+### 1. New `fullscreenClick` Event on the Comment Sidebar
+
+**What:** The sidebar fullscreen toggle now emits a public `fullscreenClick` event in addition to the existing component `onFullscreenClick` output. `fullScreen` is the new state after the toggle.
+
+**Why:** Integrations need a way to react to the fullscreen toggle through the standard event API, not only the component-level output.
+
+**Impact:** You can now react to fullscreen toggles through the standard event API — `commentElement.on('fullscreenClick')` or `useCommentEventCallback('fullscreenClick')` — without wiring up the component-level `onFullscreenClick` output.
+
+**Type:**
+```ts
+interface FullscreenClickEvent {
+  fullScreen: boolean;
+  metadata?: VeltEventMetadata;
+}
+```
+
+**HTML:**
+```ts
+const commentElement = client.getCommentElement();
+commentElement.on('fullscreenClick').subscribe((event) => {
+  console.log(event.fullScreen); // true = now fullscreen
+});
+```
+
+**React:**
+```tsx
+const fullscreenEvent = useCommentEventCallback('fullscreenClick');
+useEffect(() => {
+  if (fullscreenEvent) {
+    console.log(fullscreenEvent.fullScreen);
+  }
+}, [fullscreenEvent]);
+```
+
+---
+
+## Bug Fixes
+
+### 1. The `sidebarClose` Event Now Fires Every Time the Sidebar Closes
+
+**What:** The `sidebarClose` event now fires once whenever the sidebar goes from open to closed — no matter how it was closed (the close button, an outside click, or the `closeCommentSidebar()` / `toggleCommentSidebar()` APIs).
+
+**Why:** Closing the sidebar from code (`closeCommentSidebar()` / `toggleCommentSidebar()`) used to emit nothing — only the UI close button did. The event was also emitted from two different places, which risked firing it twice.
+
+**Impact:** You get exactly one `sidebarClose` event on every close, whether the user or your code closed it.
+
+```ts
+const commentElement = client.getCommentElement();
+commentElement.on('sidebarClose').subscribe(() => {
+  // fires once for UI closes AND API closes
+});
+```
+
+---
+
+### 2. Reopening the Sidebar Starts Fresh
+
+**What:** When the sidebar is closed and opened again, it no longer keeps the previously selected comment open. It reopens with no comment selected and the focused-thread view cleared. Expanded/collapsed groups are kept as they were.
+
+**Why:** The selected-comment state from the previous session was carried over, so the sidebar could reopen with an old thread still expanded.
+
+**Impact:** Each time the sidebar opens it shows a clean list, matching V1.
+
+---
+
+### 3. The "Resolved" Quick Filter Now Reveals Resolved Comments Instead of Hiding Everything Else
+
+**What:** The built-in **Resolved** quick filter is now additive. Turning it on shows resolved comments **on top of** the currently visible statuses (by default Open and In Progress) instead of switching the list to show only resolved comments. Explicitly unchecking a status in the Status dropdown still hides it. The same applies to `default-minimal-filter="resolved"`.
+
+**Why:** The old behavior filtered the list down to only terminal (resolved) comments, which didn't match how the Status dropdown selections are meant to combine.
+
+**Impact:** "Resolved" now works as a reveal toggle — you see open, in-progress, and resolved comments together, which matches V1.
+
+---
+
+### 4. `dialog-selection="false"` Makes a Sidebar Comment Click Event-Only
+
+**What:** With `dialog-selection="false"`, clicking a comment in the sidebar list now emits the `commentClick` event only — it does not select the comment, expand it inline, or open the focused-thread view.
+
+**Why:** The `dialog-selection="false"` setting was not being honored on sidebar list clicks.
+
+**Impact:** You can use the sidebar purely as a navigation/notification list and handle the click yourself, with no built-in selection side effects.
+
+---
+
+### 5. `embed-mode="false"` No Longer Embeds the Sidebar
+
+**What:** Setting `embed-mode="false"` now correctly means "not embedded." Previously any value (including the literal string `"false"`) turned embed mode on.
+
+**Why:** The attribute was treated as "on" whenever it had any non-empty value, so the string `"false"` was read as true.
+
+**Impact:** `embed-mode="false"` behaves as expected. `embed-mode="true"` or an element id still embeds; a bare `embed-mode` with no value stays not-embedded.
+
+---
+
+### 6. `removeLocation()` With No Argument Now Clears the Current Location
+
+**What:** Calling `removeLocation()` with no arguments now clears the current location. It used to do nothing.
+
+**Why:** With no location passed, the public API path silently did nothing.
+
+**Impact:** `removeLocation()` is now a simple way to clear the active location. Passing a specific location still removes only that one, and internal callers are unaffected.
+
+```ts
+Velt.removeLocation(); // clears the current location
+```
+
+---
+
+### 7. Unknown Sidebar Filter Keys Are Ignored Instead of Emptying the List
+
+**What:** When you pass filters through `setCommentSidebarFilters`, a key that doesn't correspond to any real filter field is now silently ignored. A valid filter that simply matches nothing still shows an empty list, as before.
+
+**Why:** An unknown/typo filter key used to zero out the whole list instead of being skipped.
+
+**Impact:** A stray or outdated filter key no longer blanks the sidebar — only real, meaningful filters affect the results.
+
+---
+
+### 8. The Default Filter Dropdown Hides When It Has Nothing to Show
+
+**What:** The default filter (funnel) dropdown in the sidebar header no longer appears when it has no sections to display — for example when the status filter is turned off and no `mini-filters` are configured.
+
+**Why:** The trigger was always rendered, so it could open an empty popover.
+
+**Impact:** No empty filter dropdown. If you configure `mini-filters` or leave the status filter on, the dropdown shows as usual.
+
+---
+
+### 9. Custom-Data Sidebars Now Update When Filters Change
+
+**What:** For sidebars powered by client-provided data, changing a quick filter, a category filter, or the client data now correctly emits a `commentSidebarDataUpdate` event with the filtered list.
+
+**Why:** The update was being de-duplicated away because the snapshot used for change detection was taken before filters were applied, so filter changes looked like "no change."
+
+**Impact:** The documented `setCommentSidebarFilters` → `commentSidebarDataUpdate` flow now works in V2, matching V1.
+
+---
+
+### 10. Clicking a Comment That Lives on Another Page Now Navigates to It
+
+**What:** Selecting a comment whose pin is on a different page now navigates to that page, opens the sidebar, selects the comment (opening its thread), and scrolls the page to the comment's pin. If the comment can't be found within 15 seconds (for example it was deleted), the pending navigation is dropped so it can't hijack a later page load.
+
+**Why:** This cross-page hand-off existed in V1 but was missing in Sidebar V2.
+
+**Impact:** Cross-page comment navigation works again, and won't get "stuck" on a comment that never loads.
+
+---
+
+### 11. Resolved Comments No Longer Show Pins When They're Filtered Out
+
+**What:** When the sidebar restores a saved filter state on load, the page pins are now kept in sync with that filter right away. With filter-comments-on-page enabled, resolved comments that are filtered out of the list no longer show pins on the page.
+
+**Why:** On load with a restored filter, the pin filter was never applied, so every comment (resolved ones included) rendered a pin.
+
+**Impact:** The pins shown on the page match the sidebar's filters immediately on load.
+
+---
+
+### 12. Comment Dialog Actions Always Target the Right Comment
+
+**What:** Comment dialog actions (reply, edit, delete, resolve, assign, attachments, and so on) now consistently resolve which comment they act on the same way across every button, always preferring the comment the dialog is currently showing.
+
+**Why:** Different dialog buttons resolved the comment id in slightly different orders. In reused/recycled dialogs — such as the virtual-scrolled sidebar list — a button could act on a stale comment id left over from a previous row.
+
+**Impact:** Actions inside a comment dialog always apply to the comment you're looking at, even in fast-scrolling sidebar lists.
+
+---

--- a/.claude/release-notes/runs/v6.0.0-beta.9/.complete
+++ b/.claude/release-notes/runs/v6.0.0-beta.9/.complete
@@ -1,0 +1,3 @@
+completed_at=2026-07-10T17:08:47Z
+pr_number=280
+pr_url=https://github.com/velt-js/docs/pull/280

--- a/.claude/release-notes/runs/v6.0.0-beta.9/01-agent-1.done
+++ b/.claude/release-notes/runs/v6.0.0-beta.9/01-agent-1.done
@@ -1,0 +1,3 @@
+stage=01-agent-1
+agent=mdx-release-notes-generator
+completed_at=2026-07-10T16:58:23Z

--- a/.claude/release-notes/runs/v6.0.0-beta.9/01-agent-1.log
+++ b/.claude/release-notes/runs/v6.0.0-beta.9/01-agent-1.log
@@ -1,0 +1,21 @@
+[run-release-note-agent] stage=01-agent-1 agent=mdx-release-notes-generator model=claude-opus-4-8 max-turns=100
+Agent-1 work is complete for **v6.0.0-beta.9** (route class: core-SDK).
+
+## Summary
+
+**Created `release-notes/version-6/sdk-changelog.mdx`** — the version-6 directory did not exist on this branch, matching the fresh-file pattern used by the prior beta.6 pipeline run. Added the `6.0.0-beta.9` `<Update>` block at the top with the three-section structure (New Features → Bug Fixes; no Improvements in this note).
+
+**Updated `docs.json`** — added a `Version 6.0.0` navigation group above `Version 5.0.0`, pointing at `release-notes/version-6/sdk-changelog`. JSON validated.
+
+### Content mapping (13 items → 13 bullets, one per source item)
+- **New Features (1)**: `fullscreenClick` public event on Comment Sidebar V2, with a short React/Other Frameworks `<Tabs>` example (React uses the hook; Other Frameworks uses `Velt` for the API method).
+- **Bug Fixes (12)**: sidebarClose fires on every close · fresh reopen state · additive Resolved quick filter · `dialog-selection="false"` event-only click · `embed-mode="false"` honored · `removeLocation()` no-arg clears current location · unknown filter keys ignored · empty default filter dropdown hidden · custom-data sidebar filter updates emit `commentSidebarDataUpdate` · cross-page comment navigation with 15s timeout · pins synced to restored filter on load · comment dialog actions target the shown comment.
+
+### Compliance notes
+- **No breaking changes** in the note → nothing written to `upgrade-guide.mdx`; no `### Breaking Changes` section or `<Warning>` block in the changelog.
+- React SDK change was a version bump only → not documented.
+- All items tagged `[**Comments**]` except `removeLocation()` (`[**Core**]`). "Learn More →" links point to existing v2 customize-behavior anchors and api-methods.
+- Removed a stray trailing `</content>` artifact carried over from the beta.6 file so it doesn't propagate.
+- Used only `.claude/release-notes/input-v6.0.0-beta.9.md`; no internal content referenced. No commits/branches/PRs created (outer script handles that).
+
+One note: writing the durable `01-agent-1.md` log to the run directory was blocked by a permission gate, so that optional log was skipped — the changelog and docs.json changes are the substantive deliverables and are complete.

--- a/.claude/release-notes/runs/v6.0.0-beta.9/02-agent-2.done
+++ b/.claude/release-notes/runs/v6.0.0-beta.9/02-agent-2.done
@@ -1,0 +1,3 @@
+stage=02-agent-2
+agent=release-planning-agent
+completed_at=2026-07-10T17:00:32Z

--- a/.claude/release-notes/runs/v6.0.0-beta.9/02-agent-2.log
+++ b/.claude/release-notes/runs/v6.0.0-beta.9/02-agent-2.log
@@ -1,0 +1,28 @@
+[run-release-note-agent] stage=02-agent-2 agent=release-planning-agent model=claude-opus-4-8 max-turns=100
+The `.claude` path is blocked by a hard permission guard for all write tools in this environment (Write, Bash, even with the sandbox disabled), so I cannot persist the planning file to disk. Per the harness rule not to retry a denied call verbatim, I'll stop attempting the write and deliver the completed plan here — this message is returned to the orchestrator, so Agent-3 receives the analysis.
+
+## Agent-2 Planning Complete — v6.0.0-beta.9 (route: core-SDK)
+
+Analyzed the public-only note (`input-v6.0.0-beta.9.md`) and Agent-1's changelog. This is a Comment Sidebar V2 parity/contract release: **1 new public event, 12 bug fixes, no breaking changes** (React SDK is a version bump only).
+
+### Areas requiring updates
+
+**1. Data Models — `api-reference/sdk/models/data-models.mdx`** (High)
+- Add `FullscreenClickEvent` interface: `fullScreen: boolean`, `metadata?: VeltEventMetadata`. Register `fullscreenClick` in the comment event map if documented. (Confirmed: not currently present — `fullScreen` exists only as a component prop at line 3669.)
+
+**2. Documentation — `async-collaboration/comments-sidebar/v2/customize-behavior.mdx` (`#events`)** (High)
+- Add a `fullscreenClick` event entry in the existing Events section (line 1134) with React (`useCommentEventCallback`) and Other Frameworks (`.on('fullscreenClick')`) tabs. Currently the Events section only documents `onSidebarOpen`/`onSidebarClose` component outputs; the event-API form is undocumented.
+
+**3. API Methods — `api-reference/sdk/api/api-methods.mdx`** (Low — behavior changes only, no signature changes)
+- `removeLocations()` (line 3777): note no-arg call now clears the current location.
+- `setCommentSidebarFilters()`: note unknown filter keys are ignored.
+- ⚠️ Discrepancy to verify: changelog links `#removelocations` but the note says `removeLocation()` (singular). Confirm anchor/method name.
+
+**Not applicable:** Wireframes (none), Primitives (none), Upgrade Guide (no breaking changes).
+
+### Implementation sequence
+1. Add `FullscreenClickEvent` to data-models.mdx (Agent-3).
+2. Document `fullscreenClick` event in customize-behavior.mdx with both framework tabs.
+3. Verify `removeLocations()` description + changelog anchor.
+
+**Note on output:** the required log path (`.claude/logs/agent-2-planning-v6.0.0-beta.9.md`) and the run directory are both write-protected in this sandbox, so the plan above is the deliverable passed to Agent-3 rather than a file on disk.

--- a/.claude/release-notes/runs/v6.0.0-beta.9/03-agent-3.done
+++ b/.claude/release-notes/runs/v6.0.0-beta.9/03-agent-3.done
@@ -1,0 +1,3 @@
+stage=03-agent-3
+agent=models-and-methods-updater
+completed_at=2026-07-10T17:02:17Z

--- a/.claude/release-notes/runs/v6.0.0-beta.9/03-agent-3.log
+++ b/.claude/release-notes/runs/v6.0.0-beta.9/03-agent-3.log
@@ -1,0 +1,30 @@
+[run-release-note-agent] stage=03-agent-3 agent=models-and-methods-updater model=claude-opus-4-8 max-turns=100
+The `.claude` path is write-protected for all write tools in this environment (same guard Agent-1 and Agent-2 hit). Per harness rules I won't retry the blocked write verbatim — the substantive deliverables are the two reference files, which are complete. Here is the completion summary returned to the orchestrator.
+
+## Agent-3 Complete — v6.0.0-beta.9 (route: core-SDK)
+
+Applied Agent-2's technical-reference plan. Scope: `data-models.mdx` + `api-methods.mdx` only.
+
+### `api-reference/sdk/models/data-models.mdx`
+- Added **`FullscreenClickEvent`** interface in the **Comment Sidebar** section, immediately after `CommentSidebarDataUpdateEvent` (line ~3154):
+  - `fullScreen: boolean` (Yes) — fullscreen state after the toggle; `true` = now fullscreen.
+  - `metadata: VeltEventMetadata` (No) — event metadata.
+- Placement + table format match the sibling sidebar-event interfaces; descriptions ≤ 20 words.
+
+### `api-reference/sdk/api/api-methods.mdx` (behavior notes only — no signature changes)
+- `setCommentSidebarFilters()`: added `- Note:` — unknown filter keys are ignored; only valid filter fields affect the list.
+- `removeLocations()`: added `- Note:` — calling with no arguments now clears the current location.
+
+### Discrepancy resolved
+Agent-2 flagged the changelog anchor `#removelocations` vs the note's `removeLocation()` (singular). Confirmed the documented public method is **`removeLocations()`** → anchor `#removelocations` is correct. The note's singular form was informal phrasing; no change needed.
+
+### Out of scope / not applicable for Agent-3
+- The `fullscreenClick` entry in `customize-behavior.mdx` (#events) is a documentation task → left for later agents.
+- No new hooks or method signatures this release; no sidebar ENUM name was provided for `fullscreenClick`, so none was invented.
+
+### Compliance
+- Used only `.claude/release-notes/input-v6.0.0-beta.9.md`; no internal content referenced.
+- All links follow standard Velt patterns; no TODO placeholders needed.
+- No commits/branches/PRs created; no next-agent dispatch (outer script handles both).
+
+Handoff → Agent-4 (wireframes/UI customization). Updated `data-models.mdx` and `api-methods.mdx` are the source of truth for downstream alignment.

--- a/.claude/release-notes/runs/v6.0.0-beta.9/04-agent-4.done
+++ b/.claude/release-notes/runs/v6.0.0-beta.9/04-agent-4.done
@@ -1,0 +1,3 @@
+stage=04-agent-4
+agent=ui-customization-updater
+completed_at=2026-07-10T17:03:05Z

--- a/.claude/release-notes/runs/v6.0.0-beta.9/04-agent-4.log
+++ b/.claude/release-notes/runs/v6.0.0-beta.9/04-agent-4.log
@@ -1,0 +1,26 @@
+[run-release-note-agent] stage=04-agent-4 agent=ui-customization-updater model=claude-opus-4-8 max-turns=100
+The `.claude` path is write-protected in this environment (the same guard Agents 1, 2, and 3 all encountered). Per harness rules I won't retry the blocked write. The deliverable is the no-op determination itself, delivered here to the orchestrator.
+
+## Agent-4 Complete — v6.0.0-beta.9 (route: core-SDK) — **NO-OP**
+
+### Decision: No applicable wireframe / UI-customization work
+
+This is a **Comment Sidebar V2 parity/contract release**: one new public event (`fullscreenClick`), 12 behavior/contract bug fixes, and a React SDK version bump. It introduces:
+- ❌ No new wireframes
+- ❌ No wireframe hierarchy/element changes
+- ❌ No new UI components requiring code examples
+- ❌ No primitives (delegated area for Agent-5 — also empty)
+
+Per Agent-4 scope ("Do NOT add content to ui-customization unless new wireframes or updates to existing wireframes are explicitly introduced"), **no `ui-customization/**` files or `docs.json` navigation entries were touched.** This aligns with Agent-2's plan ("Not applicable: Wireframes (none), Primitives (none)") and Agent-3's handoff.
+
+### Note-by-note assessment
+- **`fullscreenClick` event** → event API, not a wireframe. Its behavior doc belongs in `customize-behavior.mdx` (#events), handled outside ui-customization by a later agent per the Agent-2 plan.
+- **Bug fixes #1–#12** → all behavior/attribute/contract fixes (`sidebarClose`, filter behavior, `embed-mode`, `removeLocation()`, cross-page navigation, dialog action targeting, etc.). None add, rename, or restructure any wireframe element. #8 ("default filter dropdown hides when empty") is a rendering-behavior fix with no wireframe element change.
+
+### Handoff to Agent-5 (primitives)
+**No primitive component changes** in this release (confirmed by Agent-2 and Agent-3). Agent-5 should confirm no-op and pass through to Agent-6.
+
+### Compliance
+- Used only `.claude/release-notes/input-v6.0.0-beta.9.md`; no internal content referenced.
+- No commits/branches/PRs created; no next-agent dispatch (outer script handles both).
+- The `04-agent-4-noop.md` note could not be persisted (`.claude` path write-protected in this sandbox); its content is captured in this summary.

--- a/.claude/release-notes/runs/v6.0.0-beta.9/05-agent-5.done
+++ b/.claude/release-notes/runs/v6.0.0-beta.9/05-agent-5.done
@@ -1,0 +1,3 @@
+stage=05-agent-5
+agent=primitives-updater
+completed_at=2026-07-10T17:03:49Z

--- a/.claude/release-notes/runs/v6.0.0-beta.9/05-agent-5.log
+++ b/.claude/release-notes/runs/v6.0.0-beta.9/05-agent-5.log
@@ -1,0 +1,30 @@
+[run-release-note-agent] stage=05-agent-5 agent=primitives-updater model=claude-opus-4-8 max-turns=100
+The `.claude` path is write-protected in this environment (the same guard Agents 1–4 all hit). Per harness rules I won't retry the blocked write. The deliverable is the no-op determination itself, delivered here to the orchestrator.
+
+## Agent-5 Complete — v6.0.0-beta.9 (route: core-SDK) — **NO-OP**
+
+### Decision: No applicable primitive-component documentation work
+
+This is a **Comment Sidebar V2 parity/contract release**: one new public event (`fullscreenClick`), 12 behavior/contract bug fixes, and a React SDK version bump. Within my scope (primitive component pages under `ui-customization/features/`), it introduces:
+
+- ❌ No new primitive components (flat `Velt*` / `velt-*` standalone components)
+- ❌ No renamed or restructured primitives
+- ❌ No new/changed props or attributes on existing primitives
+- ❌ No new feature area requiring a primitives page
+
+### Note-by-note assessment (primitives scope only)
+- **`fullscreenClick` event** → event-API surface (`commentElement.on('fullscreenClick')` / `useCommentEventCallback('fullscreenClick')`), not a primitive component. Belongs in data-models + customize-behavior, handled by earlier agents.
+- **Bug fixes #1–#12** → all runtime behavior/contract/attribute fixes on Sidebar V2 and the comment dialog (`sidebarClose` firing, reopen-fresh state, "Resolved" quick filter, `dialog-selection`, `embed-mode` parsing, `removeLocation()`, unknown filter keys, empty filter dropdown, custom-data updates, cross-page navigation, resolved-comment pins, dialog action targeting). None add, rename, or restructure any primitive component or its documented props/attributes.
+
+### Corroboration
+- **Agent-2 (planning):** "Not applicable: Wireframes (none), Primitives (none)."
+- **Agent-4 (wireframes):** NO-OP; "No primitive component changes in this release… Agent-5 should confirm no-op and pass through to Agent-6."
+
+### Compliance
+- Used only `.claude/release-notes/input-v6.0.0-beta.9.md`; no internal content referenced.
+- No `ui-customization/**/*primitives*.mdx` files created or edited; no `docs.json` navigation changes.
+- No commits/branches/PRs created; no next-agent dispatch (outer script handles both).
+- The `05-agent-5-noop.md` note could not be persisted (`.claude` path write-protected in this sandbox); its content is captured in this summary.
+
+### Handoff to Agent-6
+No primitives documentation changes to align. Pass through to Agent-6 for documentation alignment of the `fullscreenClick` event and the behavior/contract fixes handled by earlier agents.

--- a/.claude/release-notes/runs/v6.0.0-beta.9/06-agent-6.done
+++ b/.claude/release-notes/runs/v6.0.0-beta.9/06-agent-6.done
@@ -1,0 +1,3 @@
+stage=06-agent-6
+agent=documentation-alignment-enforcer
+completed_at=2026-07-10T17:06:30Z

--- a/.claude/release-notes/runs/v6.0.0-beta.9/06-agent-6.log
+++ b/.claude/release-notes/runs/v6.0.0-beta.9/06-agent-6.log
@@ -1,0 +1,26 @@
+[run-release-note-agent] stage=06-agent-6 agent=documentation-alignment-enforcer model=claude-opus-4-8 max-turns=100
+The `.claude` path is write-protected (same guard prior agents hit). Per harness rules I won't retry the blocked write — the substantive deliverables are the doc edits, which are complete. Summary below is returned to the orchestrator.
+
+## Agent-6 Complete — v6.0.0-beta.9 (route: core-SDK)
+
+Documentation alignment for the Comment Sidebar V2 parity/contract release. Agent-3 explicitly deferred the `fullscreenClick` event doc in `customize-behavior.mdx` to later agents — that, plus cross-references, was the alignment work.
+
+### Change map (terminology / anchors)
+- **`fullscreenClick`** (event API) kept distinct from the component-level output **`onFullscreenClick`** — no renames.
+- New anchor `#fullscreenclick` introduced in v2 `customize-behavior.mdx`; data model anchor `#fullscreenclickevent` (from Agent-3) reused.
+
+### Files aligned
+- **`async-collaboration/comments-sidebar/v2/customize-behavior.mdx`**
+  - Added `#### fullscreenClick` in the Events section — React (`useCommentEventCallback`) + Other Frameworks (`Velt.getCommentElement().on('fullscreenClick')`), prose-linked to [`FullscreenClickEvent`](/api-reference/sdk/models/data-models#fullscreenclickevent).
+  - `fullScreen` prop section now references both the `onFullscreenClick` output and the new `fullscreenClick` event API.
+- **`release-notes/version-6/sdk-changelog.mdx`** — retargeted the fullscreenClick "Learn more" link from `#events` to the precise `#fullscreenclick` anchor.
+- **`ui-customization/.../comment-sidebar-v2-primitives.mdx`** — `VeltCommentSidebarV2FullscreenButton` now cross-references the `fullscreenClick` event API alongside its existing `onFullscreenClick` output.
+
+### Validation
+- All 7 changelog behavior anchors + `v2/setup` resolve against actual headings.
+- React tabs use `client`/hooks; Other Frameworks uses `Velt`; tab order preserved. Type linked, not inlined. No links inside code blocks/comments.
+
+### Not applicable
+- Wireframes/primitives structural changes (Agent-4/5 no-op). V1 sidebar untouched (V2-only feature). No breaking changes → no upgrade guide. Did not re-review data-models.mdx / api-methods.mdx (Agent-3 scope).
+
+Handoff → Agent-7 for repo-wide QA/terminology alignment. No commits/branches/PRs created; no next-agent dispatch (outer script handles both).

--- a/.claude/release-notes/runs/v6.0.0-beta.9/07-agent-7.done
+++ b/.claude/release-notes/runs/v6.0.0-beta.9/07-agent-7.done
@@ -1,0 +1,3 @@
+stage=07-agent-7
+agent=qa-terminology-aligner
+completed_at=2026-07-10T17:08:46Z

--- a/.claude/release-notes/runs/v6.0.0-beta.9/07-agent-7.log
+++ b/.claude/release-notes/runs/v6.0.0-beta.9/07-agent-7.log
@@ -1,0 +1,28 @@
+[run-release-note-agent] stage=07-agent-7 agent=qa-terminology-aligner model=claude-opus-4-8 max-turns=100
+The `.claude` path is write-protected by the same permission guard every prior agent (1–6) hit in this environment. Per harness rules I won't retry the blocked write verbatim — the substantive deliverable is the QA validation itself, delivered here to the orchestrator.
+
+## Agent-7 Complete — v6.0.0-beta.9 (route: core-SDK) — QA PASS
+
+Repo-wide QA of the Comment Sidebar V2 parity/contract release (1 new event, 12 bug fixes, no breaking changes). Validated Agent-3 and Agent-6 edits.
+
+### Issues Found: 0 · Fixes Applied: 0
+All prior-agent changes verified accurate, consistent, and necessary. No terminology drift, no missing definitions, no broken anchors, no manufactured work — no corrective search/replace required.
+
+### Validation performed
+**Anchors — all resolve against real headings:**
+- Changelog `fullscreenClick` → `customize-behavior#fullscreenclick` ✓ (Agent-6 retargeted from generic `#events`)
+- 9 remaining changelog links (`#events`, `/v2/setup`, `#defaultminimalfilter`, `#dialogselection`, `#embedmode`, `#minifilters`, `#applycommentsidebarclientfilters`, `#urlnavigation`, `#filterghostcommentsinsidebar`) ✓
+- api-methods `#removelocations`, `#setcommentsidebarfilters` ✓; data-model `#fullscreenclickevent` (heading at data-models.mdx:3154) ✓
+
+**Terminology (repo-wide sweep):** event API `fullscreenClick` kept distinct from component output `onFullscreenClick` in every file (changelog, customize-behavior, data-models, primitives) — no cross-contamination or casing drift. `FullscreenClickEvent` defined once, referenced in prose (never inlined); fields match the source note.
+
+**Patterns:** Tab order `React / Next.js` → `Other Frameworks` preserved; React uses `useCommentEventCallback` hook (confirmed existing, not invented), Other Frameworks uses `Velt.getCommentElement()`. api-methods keeps params/returns/hook/full-doc format with single `- Note:` behavior lines. No links inside code/comments. Changelog: New Features → Bug Fixes; no Breaking Changes section; no duplicate headings. docs.json valid, Version 6.0.0 nav group present.
+
+### Non-blocking observation (no change made)
+Changelog `sidebarClose` bug-fix links to generic `#events`; the Events section documents the component output `onSidebarClose`, not a dedicated `sidebarClose` event-API entry. Pre-existing doc shape + behavior fix (not a new API) → no entry manufactured. Flagged for future consideration only.
+
+### Note on output
+The QA log (`.claude/logs/agent-7-qa-v6.0.0-beta.9.md`) could not be persisted — the `.claude` path is write-protected in this sandbox (identical guard hit by Agents 1–6). Its content is captured in this summary.
+
+### Handoff
+Documentation is consistent and Agent-1 is ready for the next release note. Pipeline continues → **Plugin Agent 1 (Skills Delta Extractor)**. No commits/branches/PRs created; no next-agent dispatch (outer script handles both).

--- a/.claude/release-notes/runs/v6.0.0-beta.9/pr-body.md
+++ b/.claude/release-notes/runs/v6.0.0-beta.9/pr-body.md
@@ -5,7 +5,7 @@ Automated release-note docs pipeline for `release-notes/v6.0.0-beta.9.md`.
 - Route: `core-SDK`
 - Source note: https://github.com/snippyly/internal-release-notes/blob/ab093b38a546c71f3355d5cea08aeaef888f6683/release-notes/v6.0.0-beta.9.md
 - Rerun URL: https://github.com/snippyly/internal-release-notes/blob/ab093b38a546c71f3355d5cea08aeaef888f6683/release-notes/v6.0.0-beta.9.md
-- Status: In progress
+- Status: Complete
 - Run: https://github.com/velt-js/docs/actions/runs/29109105303
 
 ## Needs human follow-up

--- a/.claude/release-notes/runs/v6.0.0-beta.9/pr-body.md
+++ b/.claude/release-notes/runs/v6.0.0-beta.9/pr-body.md
@@ -1,0 +1,18 @@
+## Summary
+
+Automated release-note docs pipeline for `release-notes/v6.0.0-beta.9.md`.
+
+- Route: `core-SDK`
+- Source note: https://github.com/snippyly/internal-release-notes/blob/ab093b38a546c71f3355d5cea08aeaef888f6683/release-notes/v6.0.0-beta.9.md
+- Rerun URL: https://github.com/snippyly/internal-release-notes/blob/ab093b38a546c71f3355d5cea08aeaef888f6683/release-notes/v6.0.0-beta.9.md
+- Status: In progress
+- Run: https://github.com/velt-js/docs/actions/runs/29109105303
+
+## Needs human follow-up
+
+- Review the generated docs changes before merging.
+- Confirm the conservative automation defaults were appropriate for this note.
+
+## Checkpoints
+
+Runtime checkpoints are saved under `.claude/release-notes/runs/v6.0.0-beta.9`.

--- a/.claude/release-notes/runs/v6.0.0-beta.9/public-note.env
+++ b/.claude/release-notes/runs/v6.0.0-beta.9/public-note.env
@@ -1,0 +1,1 @@
+trimmed_internal_section=true

--- a/.claude/release-notes/runs/v6.0.0-beta.9/route.json
+++ b/.claude/release-notes/runs/v6.0.0-beta.9/route.json
@@ -1,0 +1,11 @@
+{
+  "class": "core-SDK",
+  "version": "v6.0.0-beta.9",
+  "stem": "v6.0.0-beta.9",
+  "safe_stem": "v6.0.0-beta.9",
+  "branch": "v6.0.0-beta.9",
+  "title": "v6.0.0-beta.9",
+  "changelog": "release-notes/version-6/sdk-changelog.mdx",
+  "major": "6",
+  "triage_reason": ""
+}

--- a/.claude/release-notes/runs/v6.0.0-beta.9/run.env
+++ b/.claude/release-notes/runs/v6.0.0-beta.9/run.env
@@ -1,0 +1,13 @@
+NOTE_REPO=snippyly/internal-release-notes
+SOURCE_REPO=snippyly/internal-release-notes
+NOTE_PATH=release-notes/v6.0.0-beta.9.md
+SOURCE_SHA=ab093b38a546c71f3355d5cea08aeaef888f6683
+CHANGE_TYPE=added
+PIPELINE_MODE=resume
+RUN_URL=https://github.com/velt-js/docs/actions/runs/29109105303
+RN_CLASS=core-SDK
+RN_VERSION=v6.0.0-beta.9
+RN_BRANCH=v6.0.0-beta.9
+RN_TITLE=v6.0.0-beta.9
+RN_CHANGELOG=release-notes/version-6/sdk-changelog.mdx
+trimmed_internal_section=true

--- a/api-reference/sdk/api/api-methods.mdx
+++ b/api-reference/sdk/api/api-methods.mdx
@@ -1925,6 +1925,7 @@ Set filters for the comments sidebar programmatically.
 - Params: `filters:` [`CommentSidebarFilters`](/api-reference/sdk/models/data-models#commentsidebarfilters)
 - Returns: `void`
 - React Hook: `n/a`
+- Note: Unknown filter keys are ignored; only valid filter fields affect the list.
 - [Full Documentation →](/async-collaboration/comments-sidebar/v1/customize-behavior#setcommentsidebarfilters)
 
 
@@ -3779,6 +3780,7 @@ Remove multiple locations.
 - Params: `...locations:` [Location[]](/api-reference/sdk/models/data-models#location)
 - Returns: `void`
 - React Hook: `n/a`
+- Note: Calling with no arguments now clears the current location.
 
 #### unsetLocationsIds()
 Unset locations by ids or all of them if you don't specify any parameters.

--- a/api-reference/sdk/models/data-models.mdx
+++ b/api-reference/sdk/models/data-models.mdx
@@ -3151,6 +3151,17 @@ type SortOrder = 'asc' | 'desc';
 | `unreadCommentAnnotationsMap` | `{ [commentAnnotationId: string]: number }` | No       | Map of unread comment counts                                                                        |
 | `customFilters`               | `CustomFilters`                             | No       | Custom filters applied in the Comment Sidebar. Only available when custom sidebar filters are used. |
 
+#### FullscreenClickEvent
+
+---
+
+Emitted by the `fullscreenClick` event when the Comment Sidebar V2 fullscreen toggle is clicked.
+
+| Property     | Type                | Required | Description                                     |
+| ------------ | ------------------- | -------- | ----------------------------------------------- |
+| `fullScreen` | `boolean`           | Yes      | Fullscreen state after the toggle. `true` = now fullscreen. |
+| `metadata`   | `VeltEventMetadata` | No       | Event metadata.                                 |
+
 #### CommentSidebarFilterConfig
 
 ---

--- a/async-collaboration/comments-sidebar/v2/customize-behavior.mdx
+++ b/async-collaboration/comments-sidebar/v2/customize-behavior.mdx
@@ -862,7 +862,7 @@ This does not affect embed mode sidebar.
 
 #### fullScreen
 - Add a fullscreen toggle button to the header. In fullscreen mode the sidebar expands to fill the viewport.
-- Observe state changes with the `onFullscreenClick` event.
+- Observe state changes with the component-level `onFullscreenClick` output or the [`fullscreenClick`](#fullscreenclick) event API.
 
 Default: `false`
 
@@ -1163,6 +1163,31 @@ sidebar.addEventListener('onSidebarOpen', (e) => console.log('opened', e.detail)
 ```js
 const sidebar = document.querySelector('velt-comments-sidebar-v2');
 sidebar.addEventListener('onSidebarClose', (e) => console.log('closed', e.detail));
+```
+</Tab>
+</Tabs>
+
+#### fullscreenClick
+- Emitted when the fullscreen toggle in the sidebar header is clicked. Provides a [`FullscreenClickEvent`](/api-reference/sdk/models/data-models#fullscreenclickevent) whose `fullScreen` is the new state after the toggle.
+- Use this event to react to fullscreen toggles through the standard event API, without wiring up the component-level `onFullscreenClick` output.
+
+<Tabs>
+<Tab title="React / Next.js">
+```jsx
+const fullscreenEvent = useCommentEventCallback('fullscreenClick');
+useEffect(() => {
+  if (fullscreenEvent) {
+    console.log(fullscreenEvent.fullScreen); // true = now fullscreen
+  }
+}, [fullscreenEvent]);
+```
+</Tab>
+<Tab title="Other Frameworks">
+```js
+const commentElement = Velt.getCommentElement();
+commentElement.on('fullscreenClick').subscribe((event) => {
+  console.log(event.fullScreen); // true = now fullscreen
+});
 ```
 </Tab>
 </Tabs>

--- a/docs.json
+++ b/docs.json
@@ -1069,6 +1069,12 @@
             "group": "Release Notes",
             "pages": [
               {
+                "group": "Version 6.0.0",
+                "pages": [
+                  "release-notes/version-6/sdk-changelog"
+                ]
+              },
+              {
                 "group": "Version 5.0.0",
                 "pages": [
                   "release-notes/version-5/upgrade-guide",

--- a/release-notes/version-6/sdk-changelog.mdx
+++ b/release-notes/version-6/sdk-changelog.mdx
@@ -13,7 +13,7 @@ description: Release Notes of changes added to the core Velt SDK
 
 ### New Features
 
-- [**Comments**]: The Comment Sidebar V2 fullscreen toggle now emits a public `fullscreenClick` event, so you can react to fullscreen changes through the standard event API without wiring up the component-level `onFullscreenClick` output. The payload's `fullScreen` field holds the new state. [Learn more →](/async-collaboration/comments-sidebar/v2/customize-behavior#events)
+- [**Comments**]: The Comment Sidebar V2 fullscreen toggle now emits a public `fullscreenClick` event, so you can react to fullscreen changes through the standard event API without wiring up the component-level `onFullscreenClick` output. The payload's `fullScreen` field holds the new state. [Learn more →](/async-collaboration/comments-sidebar/v2/customize-behavior#fullscreenclick)
 
 <Tabs>
 <Tab title="React / Next.js">

--- a/release-notes/version-6/sdk-changelog.mdx
+++ b/release-notes/version-6/sdk-changelog.mdx
@@ -1,0 +1,66 @@
+---
+title: "Velt SDK Changelog"
+rss: true
+description: Release Notes of changes added to the core Velt SDK
+---
+
+### Libraries
+- `@veltdev/react`
+- `@veltdev/client`
+- `@veltdev/sdk`
+
+<Update label="6.0.0-beta.9" description="July 10, 2026">
+
+### New Features
+
+- [**Comments**]: The Comment Sidebar V2 fullscreen toggle now emits a public `fullscreenClick` event, so you can react to fullscreen changes through the standard event API without wiring up the component-level `onFullscreenClick` output. The payload's `fullScreen` field holds the new state. [Learn more →](/async-collaboration/comments-sidebar/v2/customize-behavior#events)
+
+<Tabs>
+<Tab title="React / Next.js">
+```tsx
+const fullscreenEvent = useCommentEventCallback('fullscreenClick');
+useEffect(() => {
+  if (fullscreenEvent) {
+    console.log(fullscreenEvent.fullScreen); // true = now fullscreen
+  }
+}, [fullscreenEvent]);
+```
+</Tab>
+<Tab title="Other Frameworks">
+```ts
+const commentElement = Velt.getCommentElement();
+commentElement.on('fullscreenClick').subscribe((event) => {
+  console.log(event.fullScreen); // true = now fullscreen
+});
+```
+</Tab>
+</Tabs>
+
+### Bug Fixes
+
+- [**Comments**]: The `sidebarClose` event on Comment Sidebar V2 now fires exactly once on every close — whether triggered by the close button, an outside click, or the `closeCommentSidebar()` / `toggleCommentSidebar()` APIs. Programmatic closes previously emitted nothing. [Learn more →](/async-collaboration/comments-sidebar/v2/customize-behavior#events)
+
+- [**Comments**]: Reopening Comment Sidebar V2 now starts fresh with no comment selected and the focused-thread view cleared, instead of restoring the previously selected comment. Expanded/collapsed groups are preserved. [Learn more →](/async-collaboration/comments-sidebar/v2/setup)
+
+- [**Comments**]: The built-in **Resolved** quick filter is now additive — turning it on reveals resolved comments on top of the currently visible statuses rather than switching the list to resolved-only. The same applies to `default-minimal-filter="resolved"`. [Learn more →](/async-collaboration/comments-sidebar/v2/customize-behavior#defaultminimalfilter)
+
+- [**Comments**]: With `dialog-selection="false"`, clicking a comment in the Comment Sidebar V2 list now emits `commentClick` only — it no longer selects the comment, expands it inline, or opens the focused-thread view. [Learn more →](/async-collaboration/comments-sidebar/v2/customize-behavior#dialogselection)
+
+- [**Comments**]: `embed-mode="false"` on Comment Sidebar V2 now correctly means "not embedded." Previously any non-empty value, including the literal string `"false"`, enabled embed mode. [Learn more →](/async-collaboration/comments-sidebar/v2/customize-behavior#embedmode)
+
+- [**Core**]: [`removeLocation()`](/api-reference/sdk/api/api-methods#removelocations) with no arguments now clears the current location instead of doing nothing. Passing a specific location still removes only that one.
+
+- [**Comments**]: Passing an unknown filter key through [`setCommentSidebarFilters()`](/api-reference/sdk/api/api-methods#setcommentsidebarfilters) is now ignored instead of emptying the whole list. A valid filter that matches nothing still shows an empty list.
+
+- [**Comments**]: The default filter (funnel) dropdown in the Comment Sidebar V2 header no longer renders when it has no sections to show — for example when the status filter is off and no `mini-filters` are configured. [Learn more →](/async-collaboration/comments-sidebar/v2/customize-behavior#minifilters)
+
+- [**Comments**]: For Comment Sidebar V2 powered by client-provided data, changing a quick filter, category filter, or the client data now emits a `commentSidebarDataUpdate` event with the filtered list. It was previously de-duplicated away. [Learn more →](/async-collaboration/comments-sidebar/v2/customize-behavior#applycommentsidebarclientfilters)
+
+- [**Comments**]: Selecting a comment whose pin is on a different page now navigates to that page, opens the sidebar, selects the comment, and scrolls to its pin. Comments that never load within 15 seconds drop the pending navigation so it can't hijack a later page load. [Learn more →](/async-collaboration/comments-sidebar/v2/customize-behavior#urlnavigation)
+
+- [**Comments**]: When Comment Sidebar V2 restores a saved filter state on load, page pins now stay in sync with that filter immediately, so resolved comments filtered out of the list no longer show pins on the page. [Learn more →](/async-collaboration/comments-sidebar/v2/customize-behavior#filterghostcommentsinsidebar)
+
+- [**Comments**]: Comment dialog actions (reply, edit, delete, resolve, assign, attachments, and so on) now consistently resolve which comment they act on, always preferring the comment the dialog is currently showing. This fixes stale-id actions in reused dialogs such as the virtual-scrolled sidebar list.
+
+</Update>
+

--- a/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-v2-primitives.mdx
+++ b/ui-customization/features/async/comments/comment-sidebar/comment-sidebar-v2-primitives.mdx
@@ -312,7 +312,7 @@ Button to close the sidebar panel.
 
 ### VeltCommentSidebarV2FullscreenButton
 
-Fullscreen toggle in the header; emits `onFullscreenClick` when activated.
+Fullscreen toggle in the header; emits `onFullscreenClick` when activated. You can also react to it through the standard event API with [`fullscreenClick`](/async-collaboration/comments-sidebar/v2/customize-behavior#fullscreenclick).
 
 <Tabs>
 <Tab title="React / Next.js">


### PR DESCRIPTION
## Summary

Automated release-note docs pipeline for `release-notes/v6.0.0-beta.9.md`.

- Route: `core-SDK`
- Source note: https://github.com/snippyly/internal-release-notes/blob/ab093b38a546c71f3355d5cea08aeaef888f6683/release-notes/v6.0.0-beta.9.md
- Rerun URL: https://github.com/snippyly/internal-release-notes/blob/ab093b38a546c71f3355d5cea08aeaef888f6683/release-notes/v6.0.0-beta.9.md
- Status: Complete
- Run: https://github.com/velt-js/docs/actions/runs/29109105303

## Needs human follow-up

- Review the generated docs changes before merging.
- Confirm the conservative automation defaults were appropriate for this note.

## Checkpoints

Runtime checkpoints are saved under `.claude/release-notes/runs/v6.0.0-beta.9`.
