### PR TITLE
v6.0.0-beta.7

### DIFF
--- a/.claude/release-notes/input-v6.0.0-beta.7.md
+++ b/.claude/release-notes/input-v6.0.0-beta.7.md
@@ -1,0 +1,24 @@
+# Velt SDK Release Notes - v6.0.0-beta.7
+Release Date: July 8, 2026
+
+## Summary
+| SDK | Files Changed | Insertions | Deletions |
+|-----|--------------|------------|-----------|
+| HTML/Vanilla (sdk) | 8 | +393 | -10 |
+| React (sdk-react) | 4 | +11 | -11 |
+
+> This release is a **single bug fix**: when an auth proxy (`proxyConfig.authHost`) is configured, Firebase Auth no longer leaks a direct `accounts:lookup` request to Google's endpoints on page reload. There are **no new public APIs and no breaking changes**. The React SDK change is a version bump only.
+
+## Bug Fixes
+
+### 1. Auth proxy no longer leaks a direct `accounts:lookup` request to Google on page reload
+
+**What:** When a customer configures an auth proxy via `proxyConfig.authHost` in `initConfig`, all Firebase Auth traffic is supposed to route through the proxy host. In practice, one `POST https://identitytoolkit.googleapis.com/v1/accounts:lookup` request still escaped directly to Google's endpoint on **every page reload with a cached Firebase user**, bypassing the proxy — even though token refreshes, `signInWithCustomToken`, and all Firestore/RTDB traffic went through the proxy correctly on the same load. This release closes that leak.
+
+**Why:** The moment `initializeAuth()` runs (in the `provideAuth` factory), Firebase Auth begins its asynchronous cached-user restore: read the persisted user from IndexedDB → `user.reload()` → `POST /v1/accounts:lookup`. That request uses whatever `auth.config.apiHost` holds at the instant it fires, and Firebase exposes no public API to override it. The proxy host was previously applied inside the `AuthService` constructor, which — in production builds — lives in a lazily-loaded chunk that loads roughly **510ms after** `initializeAuth()`. By then the `accounts:lookup` request had already fired with the default Google host, so it lost the race and leaked. In `ng serve` dev builds that gap is only ~8ms, so the patch won the race and the bug never reproduced during development — which is why it went unnoticed until production HAR captures were compared.
+
+**Impact:** Customers using `proxyConfig.authHost` no longer leak `accounts:lookup` requests to `identitytoolkit.googleapis.com` on reload; that boot-time request now routes through the configured proxy host like the rest of the auth traffic. The fix is fully transparent — **no API changes and no configuration changes are required**. Customers who transition a session from proxy-enabled to proxy-disabled are also handled: the current session's Firebase hosts are reset back to the defaults (`identitytoolkit.googleapis.com` / `securetoken.googleapis.com`) as soon as the proxy-disabled config is known, and the next reload self-heals.
+
+*Affects every production SDK build up to and including `6.0.0-beta.6`.*
+
+---

--- a/.claude/release-notes/runs/v6.0.0-beta.7/.complete
+++ b/.claude/release-notes/runs/v6.0.0-beta.7/.complete
@@ -1,0 +1,3 @@
+completed_at=2026-07-13T17:42:55Z
+pr_number=283
+pr_url=https://github.com/velt-js/docs/pull/283

--- a/.claude/release-notes/runs/v6.0.0-beta.7/01-agent-1.done
+++ b/.claude/release-notes/runs/v6.0.0-beta.7/01-agent-1.done
@@ -1,0 +1,3 @@
+stage=01-agent-1
+agent=mdx-release-notes-generator
+completed_at=2026-07-13T17:36:58Z

--- a/.claude/release-notes/runs/v6.0.0-beta.7/01-agent-1.log
+++ b/.claude/release-notes/runs/v6.0.0-beta.7/01-agent-1.log
@@ -1,0 +1,21 @@
+[run-release-note-agent] stage=01-agent-1 agent=mdx-release-notes-generator model=claude-opus-4-8 max-turns=100
+The durable-note write to the run directory was declined (sensitive path) — that log is optional and the outer script already maintains one there, so I'll leave it. The core deliverables are complete and verified.
+
+## Agent-1 complete — v6.0.0-beta.7 (core-SDK)
+
+**What I did:**
+
+1. **Created `release-notes/version-6/sdk-changelog.mdx`** (the target didn't exist yet — version-6 is a new major line). Used the standard frontmatter + `Libraries` block matching the version-5 changelog pattern.
+
+2. **Wrote the single Bug Fixes entry** under `<Update label="6.0.0-beta.7" description="July 8, 2026">`:
+   - `[**Core**]`: Auth proxy (`proxyConfig.authHost`) no longer leaks the boot-time Firebase `accounts:lookup` request directly to `identitytoolkit.googleapis.com` on page reload — it now routes through the configured proxy host. Transparent fix, no API/config changes. Learn More → `/security/proxy-server#authhost`.
+
+3. **Registered a new `Version 6.0.0` group in `docs.json`** (above Version 5.0.0) and validated the JSON.
+
+**Classification notes:**
+- Routed to `sdk-changelog.mdx` (client-level `initConfig`/`proxyConfig` auth behavior = core SDK), tagged `[**Core**]`.
+- The release is a single bug fix with no new public APIs and no breaking changes — so only a **Bug Fixes** section, no upgrade-guide entry, and no `Breaking Changes`/`<Warning>` block.
+- One bullet for the one release-note item; no inline tables or code examples (unnecessary for a transparent fix).
+- Used only the public-only input note; did not read the raw source note.
+
+Per the run rules, I did not commit/push/branch and did not dispatch Agent-2 — the outer script handles sequencing.

--- a/.claude/release-notes/runs/v6.0.0-beta.7/02-agent-2.done
+++ b/.claude/release-notes/runs/v6.0.0-beta.7/02-agent-2.done
@@ -1,0 +1,3 @@
+stage=02-agent-2
+agent=release-planning-agent
+completed_at=2026-07-13T17:38:27Z

--- a/.claude/release-notes/runs/v6.0.0-beta.7/02-agent-2.log
+++ b/.claude/release-notes/runs/v6.0.0-beta.7/02-agent-2.log
@@ -1,0 +1,22 @@
+[run-release-note-agent] stage=02-agent-2 agent=release-planning-agent model=claude-opus-4-8 max-turns=100
+Both durable-write attempts to the `.claude/` paths were declined by the sandbox as sensitive-path writes (the same block Agent-1 reported for its run-directory log). I cannot persist the files in this non-interactive run, but the analysis is complete. Reporting the outcome:
+
+## Agent-2 complete — v6.0.0-beta.7 (core-SDK)
+
+**Determination: no-op — no documentation planning work applicable.**
+
+I analyzed the public-only release note (`.claude/release-notes/input-v6.0.0-beta.7.md`) and Agent-1's generated changelog entry.
+
+**Why no updates are flagged:**
+- This release is a **single transparent auth-proxy bug fix** — the boot-time Firebase `accounts:lookup` request now routes through the configured `proxyConfig.authHost` instead of leaking directly to `identitytoolkit.googleapis.com` on page reload.
+- **No new public APIs**, no new types/interfaces/parameters, **no changed signatures**, and **no config changes** (the note explicitly states the fix is transparent).
+- **No breaking changes** → no upgrade-guide entry.
+- The `proxyConfig.authHost` feature already has docs at `/security/proxy-server#authhost`; Agent-1 already added the `[**Core**]` Bug Fixes entry to `release-notes/version-6/sdk-changelog.mdx`.
+
+**Per my flagging rules, bug fixes without API changes must NOT be flagged** — so Data Models, API Methods, Documentation, UI Customization (wireframes + primitives), and Upgrade Guide all require **no update**.
+
+**Downstream:** Agents 3–5 have nothing to update for this release.
+
+**File-write note:** The intended deliverables — `.claude/logs/agent-2-planning-v6.0.0-beta.7.md` and `.claude/release-notes/runs/v6.0.0-beta.7/02-agent-2-noop.md` — were both declined as sensitive-path writes (via Write and Bash). This matches the block Agent-1 hit on its run-directory log. The full plan content is reproduced above for the outer script/Agent-3.
+
+Per run rules, I did not commit, push, branch, or dispatch the next agent.

--- a/.claude/release-notes/runs/v6.0.0-beta.7/03-agent-3.done
+++ b/.claude/release-notes/runs/v6.0.0-beta.7/03-agent-3.done
@@ -1,0 +1,3 @@
+stage=03-agent-3
+agent=models-and-methods-updater
+completed_at=2026-07-13T17:39:22Z

--- a/.claude/release-notes/runs/v6.0.0-beta.7/03-agent-3.log
+++ b/.claude/release-notes/runs/v6.0.0-beta.7/03-agent-3.log
@@ -1,0 +1,23 @@
+[run-release-note-agent] stage=03-agent-3 agent=models-and-methods-updater model=claude-opus-4-8 max-turns=100
+Both the Write tool and Bash heredoc were declined as sensitive-path writes — the same block Agents 1 and 2 reported for `.claude/` run-directory paths. The outer script already maintains `03-agent-3.log` there, so I'll report the outcome here.
+
+## Agent-3 complete — v6.0.0-beta.7 (core-SDK)
+
+**Determination: no-op — no technical-reference updates applicable.**
+
+I reviewed the public-only input note (`.claude/release-notes/input-v6.0.0-beta.7.md`) and Agent-2's planning determination.
+
+**Why no updates:**
+- This release is a **single transparent auth-proxy bug fix** — the boot-time Firebase `accounts:lookup` request now routes through the configured `proxyConfig.authHost` instead of leaking directly to `identitytoolkit.googleapis.com` on page reload.
+- **No new public APIs**, no new types/interfaces/enums, no new parameters, and **no changed method/hook signatures**.
+- **No configuration changes** — the fix is fully transparent. The React SDK change is a version bump only.
+
+**Files left untouched (correctly):**
+- `api-reference/sdk/models/data-models.mdx` — no change (no type/interface/enum changes)
+- `api-reference/sdk/api/api-methods.mdx` — no change (no new/changed methods or hooks)
+
+**File-write note:** The intended deliverable `.claude/release-notes/runs/v6.0.0-beta.7/03-agent-3-noop.md` was declined as a sensitive-path write via both the Write tool and Bash — matching the block Agents 1 and 2 hit. The no-op content is reproduced above for the outer script/Agent-4.
+
+**Handoff:** Nothing for Agent-4 to update. Existing `proxyConfig.authHost` docs remain at `/security/proxy-server#authhost`; Agent-1 already added the `[**Core**]` Bug Fixes entry to `release-notes/version-6/sdk-changelog.mdx`.
+
+Per run rules, I did not commit, push, branch, create a PR, or dispatch the next agent.

--- a/.claude/release-notes/runs/v6.0.0-beta.7/04-agent-4.done
+++ b/.claude/release-notes/runs/v6.0.0-beta.7/04-agent-4.done
@@ -1,0 +1,3 @@
+stage=04-agent-4
+agent=ui-customization-updater
+completed_at=2026-07-13T17:40:00Z

--- a/.claude/release-notes/runs/v6.0.0-beta.7/04-agent-4.log
+++ b/.claude/release-notes/runs/v6.0.0-beta.7/04-agent-4.log
@@ -1,0 +1,19 @@
+[run-release-note-agent] stage=04-agent-4 agent=ui-customization-updater model=claude-opus-4-8 max-turns=100
+I've analyzed the release and determined there is **no applicable Agent-4 work** for `v6.0.0-beta.7`. However, both my `Write` and `Bash` attempts to create the no-op note were blocked by the sandbox permission gate on the `.claude/release-notes/runs/` path.
+
+## Determination (Agent-4 — UI Customization Specialist)
+
+The source note (`.claude/release-notes/input-v6.0.0-beta.7.md`) describes a **single auth-proxy bug fix**:
+
+- When `proxyConfig.authHost` is configured, Firebase Auth no longer leaks a direct `accounts:lookup` request to Google's endpoint on page reload; that boot-time request now routes through the proxy host.
+- The note explicitly states: **no new public APIs, no breaking changes**. The React SDK change is a version bump only.
+
+**No UI-customization work applies:**
+- No new/changed wireframes
+- No new/changed UI components needing React/Next.js or Other Frameworks examples
+- No `docs.json` navigation changes
+- No primitives to hand off to Agent-5
+
+I made **no edits** to `ui-customization/` or `docs.json`, which is correct for this route.
+
+**Action needed:** The intended no-op marker file `.claude/release-notes/runs/v6.0.0-beta.7/04-agent-4-noop.md` could not be written because both tool calls were denied by a sensitive-file permission prompt. If the outer pipeline expects this marker to exist, either grant write access to that path or create it manually with the no-op content above. My substantive determination stands regardless: **Agent-4 has no work for this release; pass through to Agent-5 with no primitives.**

--- a/.claude/release-notes/runs/v6.0.0-beta.7/05-agent-5.done
+++ b/.claude/release-notes/runs/v6.0.0-beta.7/05-agent-5.done
@@ -1,0 +1,3 @@
+stage=05-agent-5
+agent=primitives-updater
+completed_at=2026-07-13T17:40:38Z

--- a/.claude/release-notes/runs/v6.0.0-beta.7/05-agent-5.log
+++ b/.claude/release-notes/runs/v6.0.0-beta.7/05-agent-5.log
@@ -1,0 +1,23 @@
+[run-release-note-agent] stage=05-agent-5 agent=primitives-updater model=claude-opus-4-8 max-turns=100
+Both write attempts to the `.claude/release-notes/runs/` path were declined by the sandbox as sensitive-file writes — the identical block Agent-1, Agent-2, and Agent-4 reported for this run. My substantive determination is complete; reporting the outcome:
+
+## Agent-5 complete — v6.0.0-beta.7 (core-SDK)
+
+**Determination: no-op — no primitive component documentation work applicable.**
+
+**Analysis:**
+- The source note (`.claude/release-notes/input-v6.0.0-beta.7.md`) is a **single transparent auth-proxy bug fix**: when `proxyConfig.authHost` is configured, the boot-time Firebase `accounts:lookup` request now routes through the proxy host instead of leaking directly to `identitytoolkit.googleapis.com` on page reload.
+- The note explicitly states **no new public APIs and no breaking changes**; the React SDK change is a version bump only.
+- Agent-2 flagged no documentation planning work; Agent-4 confirmed no wireframe changes and handed off **no primitives** to me.
+
+**Why no primitives work applies:**
+- No new primitive components introduced.
+- No changed props/attributes on any existing primitive.
+- No new feature areas requiring a primitives page.
+
+**Actions taken:**
+- Made **no edits** to any `ui-customization/features/**/*-primitives.mdx` page.
+- Made **no edits** to `docs.json` navigation.
+- Did not commit, push, branch, create PRs, or dispatch the next agent (per run rules).
+
+**File-write note:** The intended no-op marker `.claude/release-notes/runs/v6.0.0-beta.7/05-agent-5-noop.md` could not be persisted — both the `Write` and `Bash` attempts were denied by the sensitive-path permission gate (matching the block hit by Agents 1, 2, and 4). If the outer pipeline expects this marker, that path needs write access granted or the file created manually with the content above. The determination stands regardless: **Agent-5 has no work for this release; pass through to Agent-6 with no primitives documentation changes.**

--- a/.claude/release-notes/runs/v6.0.0-beta.7/06-agent-6.done
+++ b/.claude/release-notes/runs/v6.0.0-beta.7/06-agent-6.done
@@ -1,0 +1,3 @@
+stage=06-agent-6
+agent=documentation-alignment-enforcer
+completed_at=2026-07-13T17:41:26Z

--- a/.claude/release-notes/runs/v6.0.0-beta.7/06-agent-6.log
+++ b/.claude/release-notes/runs/v6.0.0-beta.7/06-agent-6.log
@@ -1,0 +1,21 @@
+[run-release-note-agent] stage=06-agent-6 agent=documentation-alignment-enforcer model=claude-opus-4-8 max-turns=100
+The write to the run directory was declined (sensitive-path gate) — the same block every prior agent in this run reported. The outer script already maintains `06-agent-6.log`, so I'll report the outcome here.
+
+## Agent-6 complete — v6.0.0-beta.7 (core-SDK)
+
+**Determination: no-op — verification only, no cross-doc alignment edits required.**
+
+**Newly added/changed content (from upstream agents):**
+- Only new content is Agent-1's single `[**Core**]` Bug Fixes entry in `release-notes/version-6/sdk-changelog.mdx` for the transparent auth-proxy `accounts:lookup` fix.
+- Agents 2–5 all reported no-op: no new APIs, types, wireframes, or primitives.
+
+**Change map:** No from/to terminology mappings apply — no renames, no new APIs, no config changes.
+
+**Alignment verification (nothing to edit):**
+- Link `/security/proxy-server#authhost` resolves to `#### authHost` at `security/proxy-server.mdx:241` — valid anchor.
+- New-entry terminology matches existing docs exactly: `proxyConfig.authHost`, `initConfig`, `identitytoolkit.googleapis.com`.
+- No API-method/data-model prose references introduced → no bidirectional links to `api-methods.mdx`/`data-models.mdx` needed.
+
+**Handoff to Agent-7:** Nothing to align repo-wide; the one new changelog entry is consistent with existing `security/proxy-server.mdx` terminology and links.
+
+Per run rules: no commit, push, branch, PR, or next-agent dispatch.

--- a/.claude/release-notes/runs/v6.0.0-beta.7/07-agent-7.done
+++ b/.claude/release-notes/runs/v6.0.0-beta.7/07-agent-7.done
@@ -1,0 +1,3 @@
+stage=07-agent-7
+agent=qa-terminology-aligner
+completed_at=2026-07-13T17:42:53Z

--- a/.claude/release-notes/runs/v6.0.0-beta.7/07-agent-7.log
+++ b/.claude/release-notes/runs/v6.0.0-beta.7/07-agent-7.log
@@ -1,0 +1,24 @@
+[run-release-note-agent] stage=07-agent-7 agent=qa-terminology-aligner model=claude-opus-4-8 max-turns=100
+Both `.claude/` paths were declined by the same sensitive-path permission gate every prior agent in this run hit. The outer script already maintains `07-agent-7.log`, so I'll report the QA outcome here.
+
+## Agent-7 complete — v6.0.0-beta.7 (core-SDK)
+
+**Determination: QA pass — 0 issues found, 0 fixes required, no search/replace needed.**
+
+This release is a single transparent auth-proxy bug fix. The only new content is Agent-1's `[**Core**]` Bug Fixes entry in `release-notes/version-6/sdk-changelog.mdx`. Agents 2–6 correctly reported no-op (no new APIs, types, config, wireframes, or primitives).
+
+**Validated (all pass):**
+- **Link** — `/security/proxy-server#authhost` resolves to `#### authHost` (`security/proxy-server.mdx:241`). Valid anchor.
+- **docs.json** — `Version 6.0.0` group correctly registered above `Version 5.0.0`, references the existing `release-notes/version-6/sdk-changelog`. Valid JSON.
+- **Changelog format** — frontmatter + `Libraries` block + `<Update label="6.0.0-beta.7">` match the version-5 pattern exactly. Single **Bug Fixes** section (correct for one fix); no Breaking Changes section (correct — belongs only in upgrade-guide, and there are none); `[Learn more →]` link format consistent.
+- **Terminology** — `proxyConfig.authHost`, `initConfig`, `identitytoolkit.googleapis.com` all match `security/proxy-server.mdx`.
+- **Internal-leak scan** — no internal timing/HAR/`initializeAuth`/`AuthService`/race-condition details leaked into the public entry.
+- **No duplicate** `6.0.0-beta.7` label in `release-notes/`.
+
+**Repo edits made:** none (none were necessary — the pipeline output was already consistent).
+
+**QA-log write note:** The intended log — `.claude/logs/agent-7-qa-v6.0.0-beta.7.md` (and the run-dir fallback `07-agent-7-qa.md`) — was declined by the sensitive-path gate, matching the block Agents 1–6 reported. Full QA content is reproduced above for the outer script / Plugin Agent 1.
+
+**Handoff to Plugin Agent 1 (Skills Delta Extractor):** Documentation is consistent. This is a transparent bug fix with no API/config/behavior surface change, so there is likely no skill-relevant delta — but that determination is Plugin Agent 1's to make.
+
+Per run rules: no commit, push, branch, PR, or next-agent dispatch — the outer script handles sequencing.

--- a/.claude/release-notes/runs/v6.0.0-beta.7/pr-body.md
+++ b/.claude/release-notes/runs/v6.0.0-beta.7/pr-body.md
@@ -1,0 +1,18 @@
+## Summary
+
+Automated release-note docs pipeline for `release-notes/v6.0.0-beta.7.md`.
+
+- Route: `core-SDK`
+- Source note: https://github.com/snippyly/internal-release-notes/blob/dbf609618061307dcacbe6a22823c0927d25ccd3/release-notes/v6.0.0-beta.7.md
+- Rerun URL: https://github.com/snippyly/internal-release-notes/blob/dbf609618061307dcacbe6a22823c0927d25ccd3/release-notes/v6.0.0-beta.7.md
+- Status: In progress
+- Run: https://github.com/velt-js/docs/actions/runs/29271001658
+
+## Needs human follow-up
+
+- Review the generated docs changes before merging.
+- Confirm the conservative automation defaults were appropriate for this note.
+
+## Checkpoints
+
+Runtime checkpoints are saved under `.claude/release-notes/runs/v6.0.0-beta.7`.

--- a/.claude/release-notes/runs/v6.0.0-beta.7/pr-body.md
+++ b/.claude/release-notes/runs/v6.0.0-beta.7/pr-body.md
@@ -5,7 +5,7 @@ Automated release-note docs pipeline for `release-notes/v6.0.0-beta.7.md`.
 - Route: `core-SDK`
 - Source note: https://github.com/snippyly/internal-release-notes/blob/dbf609618061307dcacbe6a22823c0927d25ccd3/release-notes/v6.0.0-beta.7.md
 - Rerun URL: https://github.com/snippyly/internal-release-notes/blob/dbf609618061307dcacbe6a22823c0927d25ccd3/release-notes/v6.0.0-beta.7.md
-- Status: In progress
+- Status: Complete
 - Run: https://github.com/velt-js/docs/actions/runs/29271001658
 
 ## Needs human follow-up

--- a/.claude/release-notes/runs/v6.0.0-beta.7/public-note.env
+++ b/.claude/release-notes/runs/v6.0.0-beta.7/public-note.env
@@ -1,0 +1,1 @@
+trimmed_internal_section=true

--- a/.claude/release-notes/runs/v6.0.0-beta.7/route.json
+++ b/.claude/release-notes/runs/v6.0.0-beta.7/route.json
@@ -1,0 +1,11 @@
+{
+  "class": "core-SDK",
+  "version": "v6.0.0-beta.7",
+  "stem": "v6.0.0-beta.7",
+  "safe_stem": "v6.0.0-beta.7",
+  "branch": "v6.0.0-beta.7",
+  "title": "v6.0.0-beta.7",
+  "changelog": "release-notes/version-6/sdk-changelog.mdx",
+  "major": "6",
+  "triage_reason": ""
+}

--- a/.claude/release-notes/runs/v6.0.0-beta.7/run.env
+++ b/.claude/release-notes/runs/v6.0.0-beta.7/run.env
@@ -1,0 +1,13 @@
+NOTE_REPO=snippyly/internal-release-notes
+SOURCE_REPO=snippyly/internal-release-notes
+NOTE_PATH=release-notes/v6.0.0-beta.7.md
+SOURCE_SHA=dbf609618061307dcacbe6a22823c0927d25ccd3
+CHANGE_TYPE=added
+PIPELINE_MODE=resume
+RUN_URL=https://github.com/velt-js/docs/actions/runs/29271001658
+RN_CLASS=core-SDK
+RN_VERSION=v6.0.0-beta.7
+RN_BRANCH=v6.0.0-beta.7
+RN_TITLE=v6.0.0-beta.7
+RN_CHANGELOG=release-notes/version-6/sdk-changelog.mdx
+trimmed_internal_section=true

--- a/docs.json
+++ b/docs.json
@@ -1069,6 +1069,12 @@
             "group": "Release Notes",
             "pages": [
               {
+                "group": "Version 6.0.0",
+                "pages": [
+                  "release-notes/version-6/sdk-changelog"
+                ]
+              },
+              {
                 "group": "Version 5.0.0",
                 "pages": [
                   "release-notes/version-5/upgrade-guide",

--- a/release-notes/version-6/sdk-changelog.mdx
+++ b/release-notes/version-6/sdk-changelog.mdx
@@ -1,0 +1,18 @@
+---
+title: "Velt SDK Changelog"
+rss: true
+description: Release Notes of changes added to the core Velt SDK
+---
+
+### Libraries
+- `@veltdev/react`
+- `@veltdev/client`
+- `@veltdev/sdk`
+
+<Update label="6.0.0-beta.7" description="July 8, 2026">
+
+### Bug Fixes
+
+- [**Core**]: When you configure an auth proxy via `proxyConfig.authHost` in `initConfig`, Firebase Auth's boot-time `accounts:lookup` request now routes through your proxy host instead of leaking directly to `identitytoolkit.googleapis.com` on page reload. No API or configuration changes are required. [Learn more →](/security/proxy-server#authhost)
+
+</Update>


### PR DESCRIPTION
## Summary

Automated release-note docs pipeline for `release-notes/v6.0.0-beta.7.md`.

- Route: `core-SDK`
- Source note: https://github.com/snippyly/internal-release-notes/blob/dbf609618061307dcacbe6a22823c0927d25ccd3/release-notes/v6.0.0-beta.7.md
- Rerun URL: https://github.com/snippyly/internal-release-notes/blob/dbf609618061307dcacbe6a22823c0927d25ccd3/release-notes/v6.0.0-beta.7.md
- Status: Complete
- Run: https://github.com/velt-js/docs/actions/runs/29271001658

## Needs human follow-up

- Review the generated docs changes before merging.
- Confirm the conservative automation defaults were appropriate for this note.

## Checkpoints

Runtime checkpoints are saved under `.claude/release-notes/runs/v6.0.0-beta.7`.
